### PR TITLE
refactor: make MultiThreaded the default mode

### DIFF
--- a/typed-store/src/rocks/iter.rs
+++ b/typed-store/src/rocks/iter.rs
@@ -6,14 +6,16 @@ use bincode::Options;
 
 use serde::de::DeserializeOwned;
 
+use super::DBRawIteratorMultiThreaded;
+
 /// An iterator over all key-value pairs in a data map.
 pub struct Iter<'a, K, V> {
-    db_iter: rocksdb::DBRawIterator<'a>,
+    db_iter: DBRawIteratorMultiThreaded<'a>,
     _phantom: PhantomData<(K, V)>,
 }
 
 impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iter<'a, K, V> {
-    pub(super) fn new(db_iter: rocksdb::DBRawIterator<'a>) -> Self {
+    pub(super) fn new(db_iter: DBRawIteratorMultiThreaded<'a>) -> Self {
         Self {
             db_iter,
             _phantom: PhantomData,

--- a/typed-store/src/rocks/keys.rs
+++ b/typed-store/src/rocks/keys.rs
@@ -5,14 +5,16 @@ use bincode::Options;
 use serde::de::DeserializeOwned;
 use std::marker::PhantomData;
 
+use super::DBRawIteratorMultiThreaded;
+
 /// An iterator over the keys of a prefix.
 pub struct Keys<'a, K> {
-    db_iter: rocksdb::DBRawIterator<'a>,
+    db_iter: DBRawIteratorMultiThreaded<'a>,
     _phantom: PhantomData<K>,
 }
 
 impl<'a, K: DeserializeOwned> Keys<'a, K> {
-    pub(crate) fn new(db_iter: rocksdb::DBRawIterator<'a>) -> Self {
+    pub(crate) fn new(db_iter: DBRawIteratorMultiThreaded<'a>) -> Self {
         Self {
             db_iter,
             _phantom: PhantomData,

--- a/typed-store/src/rocks/values.rs
+++ b/typed-store/src/rocks/values.rs
@@ -4,14 +4,16 @@ use std::marker::PhantomData;
 
 use serde::de::DeserializeOwned;
 
+use super::DBRawIteratorMultiThreaded;
+
 /// An iterator over the values of a prefix.
 pub struct Values<'a, V> {
-    db_iter: rocksdb::DBRawIterator<'a>,
+    db_iter: DBRawIteratorMultiThreaded<'a>,
     _phantom: PhantomData<V>,
 }
 
 impl<'a, V: DeserializeOwned> Values<'a, V> {
-    pub(crate) fn new(db_iter: rocksdb::DBRawIterator<'a>) -> Self {
+    pub(crate) fn new(db_iter: DBRawIteratorMultiThreaded<'a>) -> Self {
         Self {
             db_iter,
             _phantom: PhantomData,


### PR DESCRIPTION
In multithreaded mode, rocksdb uses its own locking to ensure thread-safe access to the DB:
https://docs.rs/rocksdb/latest/rocksdb/trait.ThreadMode.html

This was the intended use for this API, as evidence by storing the DB reference in `Arc`, but
the DB was opened everywhere in SingleThreaded mode, as by default.

This was a bug that the present PR correcs.