### PR TITLE
Added multi_get and Iter seek

### DIFF
--- a/typed-store/src/rocks/iter.rs
+++ b/typed-store/src/rocks/iter.rs
@@ -4,7 +4,8 @@ use std::marker::PhantomData;
 
 use bincode::Options;
 
-use serde::de::DeserializeOwned;
+use eyre::Result;
+use serde::{de::DeserializeOwned, Serialize};
 
 use super::DBRawIteratorMultiThreaded;
 
@@ -42,5 +43,15 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for Iter<'a, K, V> {
         } else {
             None
         }
+    }
+}
+
+impl<'a, K: Serialize, V> Iter<'a, K, V> {
+    pub fn seek(mut self, key: &K) -> Result<Self> {
+        let config = bincode::DefaultOptions::new()
+            .with_big_endian()
+            .with_fixint_encoding();
+        self.db_iter.seek(config.serialize(key)?);
+        Ok(self)
     }
 }

--- a/typed-store/src/rocks/iter.rs
+++ b/typed-store/src/rocks/iter.rs
@@ -47,11 +47,25 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for Iter<'a, K, V> {
 }
 
 impl<'a, K: Serialize, V> Iter<'a, K, V> {
-    pub fn seek(mut self, key: &K) -> Result<Self> {
+    /// Skips all the elements that are smaller than the given key,
+    /// and either lands on the key or the first one greater than
+    /// the key.
+    pub fn skip_to(mut self, key: &K) -> Result<Self> {
         let config = bincode::DefaultOptions::new()
             .with_big_endian()
             .with_fixint_encoding();
         self.db_iter.seek(config.serialize(key)?);
+        Ok(self)
+    }
+
+    /// Moves the iterator the element given or
+    /// the one prior to it if it does not exist. If there is
+    /// no element prior to it, it returns an empty iterator.
+    pub fn skip_prior_to(mut self, key: &K) -> Result<Self> {
+        let config = bincode::DefaultOptions::new()
+            .with_big_endian()
+            .with_fixint_encoding();
+        self.db_iter.seek_for_prev(config.serialize(key)?);
         Ok(self)
     }
 }

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -63,6 +63,41 @@ fn test_get() {
 }
 
 #[test]
+fn test_multi_get() {
+    let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
+
+    db.insert(&123, &"123".to_string())
+        .expect("Failed to insert");
+    db.insert(&456, &"456".to_string())
+        .expect("Failed to insert");
+
+    let result = db.multi_get(&[123, 456, 789]).expect("Failed to multi get");
+
+    assert_eq!(result.len(), 3);
+    assert_eq!(result[0], Some("123".to_string()));
+    assert_eq!(result[1], Some("456".to_string()));
+    assert_eq!(result[2], None);
+}
+
+#[test]
+fn test_seek() {
+    let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
+
+    db.insert(&123, &"123".to_string())
+        .expect("Failed to insert");
+    db.insert(&456, &"456".to_string())
+        .expect("Failed to insert");
+    db.insert(&789, &"789".to_string())
+        .expect("Failed to insert");
+
+    let key_vals: Vec<_> = db.iter().seek(&456).expect("Seek failed").collect();
+
+    assert_eq!(key_vals.len(), 2);
+    assert_eq!(key_vals[0], (456, "456".to_string()));
+    assert_eq!(key_vals[1], (789, "789".to_string()));
+}
+
+#[test]
 fn test_remove() {
     let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
 

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -80,7 +80,7 @@ fn test_multi_get() {
 }
 
 #[test]
-fn test_seek() {
+fn test_skip() {
     let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
 
     db.insert(&123, &"123".to_string())
@@ -100,6 +100,22 @@ fn test_seek() {
     let key_vals: Vec<_> = db.iter().skip_to(&999).expect("Seek failed").collect();
     assert_eq!(key_vals.len(), 0);
 
+    // Skip to successor of first value
+    let key_vals: Vec<_> = db.iter().skip_to(&000).expect("Skip failed").collect();
+    assert_eq!(key_vals.len(), 3);
+}
+
+#[test]
+fn test_skip_to_previous_simple() {
+    let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
+
+    db.insert(&123, &"123".to_string())
+        .expect("Failed to insert");
+    db.insert(&456, &"456".to_string())
+        .expect("Failed to insert");
+    db.insert(&789, &"789".to_string())
+        .expect("Failed to insert");
+
     // Skip to the one before the end
     let key_vals: Vec<_> = db
         .iter()
@@ -109,13 +125,8 @@ fn test_seek() {
     assert_eq!(key_vals.len(), 1);
     assert_eq!(key_vals[0], (789, "789".to_string()));
 
-    // Skip to pror of first value
-    let key_vals: Vec<_> = db.iter().skip_to(&000).expect("Seek failed").collect();
-    assert_eq!(key_vals.len(), 3);
-
-    // The counter intuitive ones
-
-    // Skip to pror of first value
+    // Skip to prior of first value
+    // Note: returns an empty iterator!
     let key_vals: Vec<_> = db
         .iter()
         .skip_prior_to(&000)
@@ -125,7 +136,7 @@ fn test_seek() {
 }
 
 #[test]
-fn test_iter_skip_to_previous() {
+fn test_iter_skip_to_previous_gap() {
     let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
     for i in 1..100 {
         if i != 50 {

--- a/typed-store/src/traits.rs
+++ b/typed-store/src/traits.rs
@@ -44,4 +44,7 @@ where
 
     /// Returns an iterator over each value in the map.
     fn values(&'a self) -> Self::Values;
+
+    /// Returns a vector of values corresponding to the keys provided.
+    fn multi_get(&self, keys: &[K]) -> Result<Vec<Option<V>>>;
 }


### PR DESCRIPTION
This PR augments DBMap with two facilities:
* A `multi_get` allowing multiple keys to be retrieved from the DB at once.
* A `seek` that allows advancing a key-value Iter to a particular key (or the one succeeding it), to support index iteration.

Two tests are added to exercise these functions.