### PR TITLE
feat: add a certificate verifier matching an expected pre-shared key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["typed-store"]
+members = ["typed-store", "rccheck"]
 
 [profile.release]
 codegen-units = 1

--- a/deny.toml
+++ b/deny.toml
@@ -48,6 +48,7 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+    "RUSTSEC-2020-0159",
     #"RUSTSEC-0000-0000",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
@@ -75,6 +76,7 @@ allow = [
     "CC0-1.0",
     "Apache-2.0",
     "ISC",
+    "LicenseRef-ring",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # List of explictly disallowed licenses
@@ -129,6 +131,12 @@ exceptions = [
     # Each entry is a crate relative path, and the (opaque) hash of its contents
     #{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
+[[licenses.clarify]]
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only

--- a/rccheck/Cargo.toml
+++ b/rccheck/Cargo.toml
@@ -11,9 +11,11 @@ edition = "2021"
 
 [dependencies]
 rustls = { version = "0.20.2", default-features = false, features = ["logging", "dangerous_configuration"] }
+serde = { version = "1.0.133", features = ["derive"]}
 tracing = "0.1.29"
 webpki = { version = "0.22.0", features = ["alloc", "std"] }
 x509-parser = "0.12.0"
 
 [dev-dependencies]
+bincode = "1.3.3"
 rcgen = "0.8.14"

--- a/rccheck/Cargo.toml
+++ b/rccheck/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "rccheck"
 version = "0.1.0"
+license = "Apache-2.0"
+authors = ["Francois Garillot <francois@mystenlabs.com>"]
+description = "a custom verifier for pre-shared keys"
+repository = "https://github.com/mystenlabs/mysten-infra"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rccheck/Cargo.toml
+++ b/rccheck/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rccheck"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rustls = { version = "0.20.2", default-features = false, features = ["logging", "dangerous_configuration"] }
+tracing = "0.1.29"
+webpki = { version = "0.22.0", features = ["alloc", "std"] }
+x509-parser = "0.12.0"
+
+[dev-dependencies]
+rcgen = "0.8.14"

--- a/rccheck/Cargo.toml
+++ b/rccheck/Cargo.toml
@@ -3,11 +3,9 @@ name = "rccheck"
 version = "0.1.0"
 license = "Apache-2.0"
 authors = ["Francois Garillot <francois@mystenlabs.com>"]
-description = "a custom verifier for pre-shared keys"
+description = "tools for rustls-based certificate verification using pre-shared public keys"
 repository = "https://github.com/mystenlabs/mysten-infra"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 rustls = { version = "0.20.2", default-features = false, features = ["logging", "dangerous_configuration"] }
@@ -20,7 +18,6 @@ anyhow = "1.0.53"
 ed25519-dalek = "1.0.1"
 ed25519 = { version = "1.3.0", features = ["pkcs8", "alloc", "zeroize"] }
 pkcs8 = { version = "0.8.0", features = ["std"] }
-der-parser = "6.0.1"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/rccheck/Cargo.toml
+++ b/rccheck/Cargo.toml
@@ -15,7 +15,14 @@ serde = { version = "1.0.133", features = ["derive"]}
 tracing = "0.1.29"
 webpki = { version = "0.22.0", features = ["alloc", "std"] }
 x509-parser = "0.12.0"
+rcgen = "0.8.14"
+anyhow = "1.0.53"
+ed25519-dalek = "1.0.1"
+ed25519 = { version = "1.3.0", features = ["pkcs8", "alloc", "zeroize"] }
+pkcs8 = { version = "0.8.0", features = ["std"] }
+der-parser = "6.0.1"
 
 [dev-dependencies]
 bincode = "1.3.3"
-rcgen = "0.8.14"
+proptest = "1.0.0"
+rand = "0.7.3"

--- a/rccheck/src/certgen.rs
+++ b/rccheck/src/certgen.rs
@@ -1,0 +1,93 @@
+use ed25519::pkcs8::EncodePrivateKey;
+
+use rcgen::{CertificateParams, KeyPair, SignatureAlgorithm};
+
+#[cfg(test)]
+#[path = "tests/certgen.rs"]
+mod certgen_tests;
+
+/**
+KISS function to generate a self signed certificate from a dalek keypair
+Given a set of domain names you want your certificate to be valid for, this function fills in the other generation parameters with
+reasonable defaults and generates a self signed certificate using the keypair passed as argument as output.
+## Example
+```
+extern crate rccheck;
+use rccheck::certgen::generate_self_signed_dalek;
+# fn main () {
+# let mut rng = rand::thread_rng();
+let subject_alt_names = vec!["localhost".to_string()];
+let kp = ed25519_dalek::Keypair::generate(&mut rng);
+
+// let cert = generate_self_signed_dalek(subject_alt_names, kp).unwrap();
+// The certificate is now valid for localhost
+# }
+```
+*/
+pub fn generate_self_signed_dalek(
+    subject_names: Vec<String>,
+    kp: ed25519_dalek::Keypair,
+) -> Result<rustls::Certificate, anyhow::Error> {
+    let keypair_bytes = dalek_to_keypair_bytes(kp);
+    let (pkcs_bytes, alg) =
+        keypair_bytes_to_pkcs8_n_algo(keypair_bytes).map_err(anyhow::Error::new)?;
+
+    let certificate = gen_certificate(subject_names, (pkcs_bytes.as_ref(), alg))?;
+    Ok(certificate)
+}
+
+fn dalek_to_keypair_bytes(dalek_kp: ed25519_dalek::Keypair) -> ed25519::KeypairBytes {
+    let private = dalek_kp.secret;
+    let _public = dalek_kp.public;
+
+    ed25519::KeypairBytes {
+        secret_key: private.to_bytes(),
+        // ring cannot handle the optional public key that would be legal der here
+        public_key: None, // Some(_public.to_bytes()),
+    }
+}
+
+fn keypair_bytes_to_pkcs8_n_algo(
+    kpb: ed25519::KeypairBytes,
+) -> Result<(pkcs8::PrivateKeyDocument, &'static SignatureAlgorithm), pkcs8::Error> {
+    // PKCS#8 v2 as described in [RFC 5958].
+    // PKCS#8 v2 keys include an additional public key field.
+    let pkcs8 = kpb.to_pkcs8_der()?;
+
+    Ok((pkcs8, &rcgen::PKCS_ED25519))
+}
+
+fn gen_certificate(
+    subject_names: Vec<String>,
+    key_pair: (&[u8], &'static SignatureAlgorithm),
+) -> Result<rustls::Certificate, anyhow::Error> {
+    let kp = KeyPair::from_der_and_sign_algo(key_pair.0, key_pair.1)?;
+
+    let mut cert_params = CertificateParams::new(subject_names);
+    cert_params.key_pair = Some(kp);
+    cert_params.distinguished_name = rcgen::DistinguishedName::new();
+    cert_params.alg = key_pair.1;
+
+    let cert = rcgen::Certificate::from_params(cert_params).expect(
+        "unreachable! from_params should only fail if the key is incompatible with params.algo",
+    );
+    let cert_bytes = cert.serialize_der()?;
+    Ok(rustls::Certificate(cert_bytes))
+}
+
+pub fn dalek_to_spki_bytes(pk: &ed25519_dalek::PublicKey) -> Vec<u8> {
+    let subject_public_key = pk.as_bytes();
+
+    let key_info = pkcs8::spki::SubjectPublicKeyInfo {
+        algorithm: pkcs8::spki::AlgorithmIdentifier {
+            // ed25519 OID
+            oid: ed25519::pkcs8::ALGORITHM_OID,
+            // use pkcs8::spki::der::asn1;
+            parameters: None, // Some(asn1::Any::from(asn1::Null)),
+        },
+        subject_public_key,
+    };
+
+    // Infallible because we know the public key is valid.
+    pkcs8::der::Encodable::to_vec(&key_info).expect("Dalek public key should be valid!")
+}

--- a/rccheck/src/certgen.rs
+++ b/rccheck/src/certgen.rs
@@ -1,3 +1,6 @@
+// Copyright(C) 2022, Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
 use ed25519::pkcs8::EncodePrivateKey;
 
 use rcgen::{CertificateParams, KeyPair, SignatureAlgorithm};
@@ -82,6 +85,8 @@ pub fn dalek_to_spki_bytes(pk: &ed25519_dalek::PublicKey) -> Vec<u8> {
         algorithm: pkcs8::spki::AlgorithmIdentifier {
             // ed25519 OID
             oid: ed25519::pkcs8::ALGORITHM_OID,
+            // some environments require a type ASN.1 NULL, use the commented alternative if so
+            // this instead matches our rcgen-produced certificates for compatibiltiy
             // use pkcs8::spki::der::asn1;
             parameters: None, // Some(asn1::Any::from(asn1::Null)),
         },

--- a/rccheck/src/lib.rs
+++ b/rccheck/src/lib.rs
@@ -15,7 +15,13 @@ use x509_parser::{traits::FromDer, x509::SubjectPublicKeyInfo};
 
 #[cfg(test)]
 #[path = "tests/psk.rs"]
-pub mod psk;
+mod psk;
+
+#[cfg(test)]
+#[path = "tests/test_utils.rs"]
+pub(crate) mod test_utils;
+
+pub mod certgen;
 
 type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];
 static SUPPORTED_SIG_ALGS: SignatureAlgorithms = &[&webpki::ECDSA_P256_SHA256, &webpki::ED25519];
@@ -39,6 +45,13 @@ static SUPPORTED_SIG_ALGS: SignatureAlgorithms = &[&webpki::ECDSA_P256_SHA256, &
 pub struct Psk<'a>(pub SubjectPublicKeyInfo<'a>);
 
 impl<'a> Eq for Psk<'a> {}
+
+impl<'a> Psk<'a> {
+    pub fn from_der(bytes: &'a [u8]) -> Result<Psk<'a>, anyhow::Error> {
+        let spki = SubjectPublicKeyInfo::from_der(bytes)?;
+        Ok(Psk(spki.1))
+    }
+}
 
 ////////////////////////////////////////////////////////////////
 /// Ser/de

--- a/rccheck/src/lib.rs
+++ b/rccheck/src/lib.rs
@@ -1,0 +1,176 @@
+// Copyright(C) 2022, Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+use std::time::SystemTime;
+
+use rustls::{
+    client::{ServerCertVerified, ServerCertVerifier},
+    server::{ClientCertVerified, ClientCertVerifier},
+};
+use x509_parser::certificate::X509Certificate;
+use x509_parser::{traits::FromDer, x509::SubjectPublicKeyInfo};
+
+#[cfg(test)]
+#[path = "tests/psk.rs"]
+pub mod psk;
+
+type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];
+static SUPPORTED_SIG_ALGS: SignatureAlgorithms = &[&webpki::ECDSA_P256_SHA256, &webpki::ED25519];
+
+/// X.509 `SubjectPublicKeyInfo` (SPKI) as defined in [RFC 5280 Section 4.1.2.7].
+///
+/// ASN.1 structure containing an [`AlgorithmIdentifier`] and public key
+/// data in an algorithm specific format.
+///
+/// ```text
+///    SubjectPublicKeyInfo  ::=  SEQUENCE  {
+///         algorithm            AlgorithmIdentifier,
+///         subjectPublicKey     BIT STRING  }
+/// ```
+///
+/// [RFC 5280 Section 4.1.2.7]: https://tools.ietf.org/html/rfc5280#section-4.1.2.7
+///
+/// We only support ECDSA P-256 & Ed25519 (for now).
+
+#[derive(PartialEq, Clone, Debug)]
+pub struct Psk<'a>(pub SubjectPublicKeyInfo<'a>);
+
+impl<'a> Eq for Psk<'a> {}
+
+/// A `ClientCertVerifier` that will ensure that every client provides a valid, expected
+/// certificate, without any name checking.
+impl<'a> ClientCertVerifier for Psk<'a> {
+    fn offer_client_auth(&self) -> bool {
+        true
+    }
+
+    fn client_auth_mandatory(&self) -> Option<bool> {
+        Some(true)
+    }
+
+    fn client_auth_root_subjects(&self) -> Option<rustls::DistinguishedNames> {
+        // We can't guarantee subjects before having seen the cert
+        None
+    }
+
+    fn verify_client_cert(
+        &self,
+        end_entity: &rustls::Certificate,
+        intermediates: &[rustls::Certificate],
+        now: SystemTime,
+    ) -> Result<ClientCertVerified, rustls::Error> {
+        // Check this matches the key we expect
+        let cert = X509Certificate::from_der(&end_entity.0[..])
+            .map_err(|_| rustls::Error::InvalidCertificateEncoding)?;
+        let spki = cert.1.public_key().clone();
+        if spki != self.0 {
+            return Err(rustls::Error::InvalidCertificateData(format!(
+                "invalid peer certificate: received {:?} instead of expected {:?}",
+                spki, self.0
+            )));
+        }
+
+        // We now check we're receiving correctly signed data with the expected key
+        let (cert, chain, trustroots) = prepare_for_self_signed(end_entity, intermediates)?;
+        let now = webpki::Time::try_from(now).map_err(|_| rustls::Error::FailedToGetCurrentTime)?;
+        cert.verify_is_valid_tls_client_cert(
+            SUPPORTED_SIG_ALGS,
+            &webpki::TlsClientTrustAnchors(&trustroots),
+            &chain,
+            now,
+        )
+        .map_err(pki_error)
+        .map(|_| ClientCertVerified::assertion())
+    }
+}
+
+impl<'a> ServerCertVerifier for Psk<'a> {
+    fn verify_server_cert(
+        &self,
+        end_entity: &rustls::Certificate,
+        intermediates: &[rustls::Certificate],
+        server_name: &rustls::ServerName,
+        scts: &mut dyn Iterator<Item = &[u8]>,
+        ocsp_response: &[u8],
+        now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        // Check this matches the key we expect
+        let cert = X509Certificate::from_der(&end_entity.0[..])
+            .map_err(|_| rustls::Error::InvalidCertificateEncoding)?;
+        let spki = cert.1.public_key().clone();
+        if spki != self.0 {
+            return Err(rustls::Error::InvalidCertificateData(format!(
+                "invalid peer certificate: received {:?} instead of expected {:?}",
+                spki, self.0
+            )));
+        }
+
+        // Then we check this is actually a valid self-signed certificate with matching name
+        let (cert, chain, trustroots) = prepare_for_self_signed(end_entity, intermediates)?;
+        let webpki_now =
+            webpki::Time::try_from(now).map_err(|_| rustls::Error::FailedToGetCurrentTime)?;
+
+        let dns_nameref = match server_name {
+            rustls::ServerName::DnsName(dns_name) => {
+                webpki::DnsNameRef::try_from_ascii_str(dns_name.as_ref())
+                    .map_err(|_| rustls::Error::UnsupportedNameType)?
+            }
+            _ => return Err(rustls::Error::UnsupportedNameType),
+        };
+
+        let cert = cert
+            .verify_is_valid_tls_server_cert(
+                SUPPORTED_SIG_ALGS,
+                &webpki::TlsServerTrustAnchors(&trustroots),
+                &chain,
+                webpki_now,
+            )
+            .map_err(pki_error)
+            .map(|_| cert)?;
+
+        let mut peekable = scts.peekable();
+        if peekable.peek().is_none() {
+            tracing::trace!("Met unvalidated certificate transparency data");
+        }
+
+        if !ocsp_response.is_empty() {
+            tracing::trace!("Unvalidated OCSP response: {:?}", ocsp_response.to_vec());
+        }
+
+        cert.verify_is_valid_for_dns_name(dns_nameref)
+            .map_err(pki_error)
+            .map(|_| ServerCertVerified::assertion())
+    }
+}
+
+type CertChainAndRoots<'a> = (
+    webpki::EndEntityCert<'a>,
+    Vec<&'a [u8]>,
+    Vec<webpki::TrustAnchor<'a>>,
+);
+
+fn prepare_for_self_signed<'a>(
+    end_entity: &'a rustls::Certificate,
+    intermediates: &'a [rustls::Certificate],
+) -> Result<CertChainAndRoots<'a>, rustls::Error> {
+    // EE cert must appear first.
+    let cert = webpki::EndEntityCert::try_from(end_entity.0.as_ref()).map_err(pki_error)?;
+
+    let intermediates: Vec<&'a [u8]> = intermediates.iter().map(|cert| cert.0.as_ref()).collect();
+
+    // reinterpret the certificate as a root, materializing the self-signed policy
+    let root = webpki::TrustAnchor::try_from_cert_der(end_entity.0.as_ref()).map_err(pki_error)?;
+
+    Ok((cert, intermediates, vec![root]))
+}
+
+fn pki_error(error: webpki::Error) -> rustls::Error {
+    use webpki::Error::*;
+    match error {
+        BadDer | BadDerTime => rustls::Error::InvalidCertificateEncoding,
+        InvalidSignatureForPublicKey => rustls::Error::InvalidCertificateSignature,
+        UnsupportedSignatureAlgorithm | UnsupportedSignatureAlgorithmForPublicKey => {
+            rustls::Error::InvalidCertificateSignatureType
+        }
+        e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {}", e)),
+    }
+}

--- a/rccheck/src/tests/certgen.rs
+++ b/rccheck/src/tests/certgen.rs
@@ -1,0 +1,87 @@
+use std::time::SystemTime;
+
+use crate::{
+    test_utils::{dalek_keypair_strategy, dalek_pubkey_strategy},
+    Psk,
+};
+
+use super::*;
+
+use proptest::prelude::*;
+use rustls::{client::ServerCertVerifier, server::ClientCertVerifier};
+
+proptest! {
+    #[test]
+    fn ed25519_keys_to_spki(
+        pub_key in dalek_pubkey_strategy(),
+    ){
+        let spki = dalek_to_spki_bytes(&pub_key);
+        let psk = Psk::from_der(&spki);
+        psk.unwrap();
+    }
+
+    #[test]
+    fn rc_gen_self_signed_dalek(
+        kp in dalek_keypair_strategy(),
+    ) {
+        let subject_alt_names = vec!["localhost".to_string()];
+        let public_key = kp.public;
+
+        let cert = generate_self_signed_dalek(subject_alt_names, kp).unwrap();
+
+        let spki = dalek_to_spki_bytes(&public_key);
+        let psk = Psk::from_der(&spki).unwrap();
+        let now = SystemTime::now();
+
+        // this passes client verification
+        psk.verify_client_cert(&cert, &[], now).unwrap();
+
+        // this passes server verification
+        let mut empty = std::iter::empty();
+        psk.verify_server_cert(
+            &cert,
+            &[],
+            &rustls::ServerName::try_from("localhost").unwrap(),
+            &mut empty,
+            &[],
+            now,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rc_gen_not_self_signed_dalek(
+        // this time the pubkey does not match the creation keypair
+        kp in dalek_keypair_strategy(),
+        public_key in dalek_pubkey_strategy(),
+    ) {
+        let subject_alt_names = vec!["localhost".to_string()];
+
+        let cert = generate_self_signed_dalek(subject_alt_names, kp).unwrap();
+
+        let spki = dalek_to_spki_bytes(&public_key);
+        let psk = Psk::from_der(&spki).unwrap();
+        let now = SystemTime::now();
+
+        // this does not pass client verification
+        assert!(psk.verify_client_cert(&cert, &[], now).err()
+            .unwrap()
+            .to_string()
+            .contains("invalid peer certificate"));
+
+        // this does not pass server verification
+        let mut empty = std::iter::empty();
+        assert!(psk.verify_server_cert(
+            &cert,
+            &[],
+            &rustls::ServerName::try_from("localhost").unwrap(),
+            &mut empty,
+            &[],
+            now,
+        )
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("invalid peer certificate"));
+    }
+}

--- a/rccheck/src/tests/certgen.rs
+++ b/rccheck/src/tests/certgen.rs
@@ -1,3 +1,6 @@
+// Copyright(C) 2022, Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::SystemTime;
 
 use crate::{

--- a/rccheck/src/tests/psk.rs
+++ b/rccheck/src/tests/psk.rs
@@ -1,0 +1,107 @@
+// Copyright(C) 2022, Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::*;
+use rcgen::generate_simple_self_signed;
+use rustls::{client::ServerCertVerifier, server::ClientCertVerifier};
+use x509_parser::traits::FromDer;
+
+#[test]
+fn rc_gen_self_client() {
+    let subject_alt_names = vec!["localhost".to_string()];
+
+    let cert = generate_simple_self_signed(subject_alt_names).unwrap();
+    let cert_bytes: Vec<u8> = cert.serialize_der().unwrap();
+    let cert_parsed = X509Certificate::from_der(&cert_bytes[..])
+        .map_err(|_| rustls::Error::InvalidCertificateEncoding)
+        .unwrap();
+    let spki = cert_parsed.1.public_key().clone();
+    let now = SystemTime::now();
+    let rstls_cert = rustls::Certificate(cert_bytes.clone());
+
+    assert!(Psk(spki).verify_client_cert(&rstls_cert, &[], now).is_ok());
+}
+
+#[test]
+fn rc_gen_not_self_client() {
+    let subject_alt_names = vec!["localhost".to_string()];
+
+    let cert = generate_simple_self_signed(subject_alt_names.clone()).unwrap();
+    let cert_bytes: Vec<u8> = cert.serialize_der().unwrap();
+
+    let other_cert = generate_simple_self_signed(subject_alt_names).unwrap();
+    let other_bytes: Vec<u8> = other_cert.serialize_der().unwrap();
+    let other_cert_parsed = X509Certificate::from_der(&other_bytes[..])
+        .map_err(|_| rustls::Error::InvalidCertificateEncoding)
+        .unwrap();
+    let spki = other_cert_parsed.1.public_key().clone();
+    let now = SystemTime::now();
+    let rstls_cert = rustls::Certificate(cert_bytes);
+
+    assert!(Psk(spki)
+        .verify_client_cert(&rstls_cert, &[], now)
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("invalid peer certificate"));
+}
+
+#[test]
+fn rc_gen_self_server() {
+    let subject_alt_names = vec!["localhost".to_string()];
+
+    let cert = generate_simple_self_signed(subject_alt_names).unwrap();
+    let cert_bytes: Vec<u8> = cert.serialize_der().unwrap();
+    let cert_parsed = X509Certificate::from_der(&cert_bytes[..])
+        .map_err(|_| rustls::Error::InvalidCertificateEncoding)
+        .unwrap();
+    let spki = cert_parsed.1.public_key().clone();
+    let now = SystemTime::now();
+    let rstls_cert = rustls::Certificate(cert_bytes.clone());
+
+    let mut empty = std::iter::empty();
+
+    assert!(Psk(spki)
+        .verify_server_cert(
+            &rstls_cert,
+            &[],
+            &rustls::ServerName::try_from("localhost").unwrap(),
+            &mut empty,
+            &[],
+            now
+        )
+        .is_ok());
+}
+
+#[test]
+fn rc_gen_not_self_server() {
+    let subject_alt_names = vec!["localhost".to_string()];
+
+    let cert = generate_simple_self_signed(subject_alt_names.clone()).unwrap();
+    let cert_bytes: Vec<u8> = cert.serialize_der().unwrap();
+
+    let other_cert = generate_simple_self_signed(subject_alt_names).unwrap();
+    let other_bytes: Vec<u8> = other_cert.serialize_der().unwrap();
+    let other_cert_parsed = X509Certificate::from_der(&other_bytes[..])
+        .map_err(|_| rustls::Error::InvalidCertificateEncoding)
+        .unwrap();
+    let spki = other_cert_parsed.1.public_key().clone();
+    let now = SystemTime::now();
+    let rstls_cert = rustls::Certificate(cert_bytes);
+
+    let mut empty = std::iter::empty();
+
+    assert!(Psk(spki)
+        .verify_server_cert(
+            &rstls_cert,
+            &[],
+            &rustls::ServerName::try_from("localhost").unwrap(),
+            &mut empty,
+            &[],
+            now
+        )
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("invalid peer certificate"));
+}

--- a/rccheck/src/tests/test_utils.rs
+++ b/rccheck/src/tests/test_utils.rs
@@ -1,3 +1,6 @@
+// Copyright(C) 2022, Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
 use proptest::prelude::*;
 use proptest::strategy::Strategy;
 

--- a/rccheck/src/tests/test_utils.rs
+++ b/rccheck/src/tests/test_utils.rs
@@ -1,0 +1,15 @@
+use proptest::prelude::*;
+use proptest::strategy::Strategy;
+
+pub fn dalek_keypair_strategy() -> impl Strategy<Value = ed25519_dalek::Keypair> {
+    any::<[u8; 32]>()
+        .prop_map(|seed| {
+            let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::from_seed(seed);
+            ed25519_dalek::Keypair::generate(&mut rng)
+        })
+        .no_shrink()
+}
+
+pub fn dalek_pubkey_strategy() -> impl Strategy<Value = ed25519_dalek::PublicKey> {
+    dalek_keypair_strategy().prop_map(|v| v.public)
+}

--- a/typed-store/Cargo.toml
+++ b/typed-store/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 rocksdb = "0.17.0"
 eyre = "0.6.5"
-serde = { version = "1.0.132", features = ["derive"]}
+serde = { version = "1.0.133", features = ["derive"]}
 bincode = "1.3.3"
 tokio = { version = "1.15.0", features = ["sync", "macros", "rt"] }
 thiserror = "1.0.30"
 collectable = "0.0.2"
 
 [dev-dependencies]
-tempfile = "3.2.0"
+tempfile = "3.3.0"


### PR DESCRIPTION
This PR adds a rustls `(Server|Client)Verifier` accepting specifically correctly self-signed certificates where the signer is an expected signer.

As such, it only uses the certificate chain to make sure the certificate is indeed self-signed, and relies on the caller instantiating the scheme with an expected public key. The set of supported algorithms is limited to two mainstream algorithms, and may or may not be expanded to match those supported by webpki in the future.


The PR also add a KISS generator for such self-signed certificates from a simple `ed25519_dalek` public key, and tests the two in conjunction.

To see an example where those custom verifiers are used, see:
https://github.com/quinn-rs/quinn/blob/main/quinn/examples/insecure_connection.rs