### PR TITLE
Adds a TypedStore error type

### DIFF
--- a/typed-store/Cargo.toml
+++ b/typed-store/Cargo.toml
@@ -13,6 +13,7 @@ eyre = "0.6.5"
 serde = "1.0.132"
 bincode = "1.3.3"
 tokio = { version = "1.15.0", features = ["sync", "macros", "rt"] }
+thiserror = "1.0.30"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/typed-store/Cargo.toml
+++ b/typed-store/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 rocksdb = "0.17.0"
 eyre = "0.6.5"
-serde = "1.0.132"
+serde = { version = "1.0.132", features = ["derive"]}
 bincode = "1.3.3"
 tokio = { version = "1.15.0", features = ["sync", "macros", "rt"] }
 thiserror = "1.0.30"

--- a/typed-store/src/lib.rs
+++ b/typed-store/src/lib.rs
@@ -27,7 +27,7 @@ pub mod rocks;
 #[path = "tests/store_tests.rs"]
 pub mod store_tests;
 
-pub type StoreError = eyre::Error;
+pub type StoreError = rocks::TypedStoreError;
 type StoreResult<T> = Result<T, StoreError>;
 
 pub enum StoreCommand<Key, Value> {

--- a/typed-store/src/rocks/errors.rs
+++ b/typed-store/src/rocks/errors.rs
@@ -1,0 +1,19 @@
+// Copyright(C) 2022, Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
+use bincode::Error as BincodeError;
+use rocksdb::Error as RocksError;
+use thiserror::Error;
+
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum TypedStoreError {
+    #[error("rocksdb error")]
+    RocksDBError(#[from] RocksError),
+    #[error("(de)serialization error")]
+    SerializationError(#[from] BincodeError),
+    #[error("the column family {0} was not registered with the database")]
+    UnregisteredColumn(String),
+    #[error("a batch operation can't operate across databases")]
+    CrossDBBatch,
+}

--- a/typed-store/src/rocks/errors.rs
+++ b/typed-store/src/rocks/errors.rs
@@ -11,10 +11,10 @@ use thiserror::Error;
 #[non_exhaustive]
 #[derive(Error, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub enum TypedStoreError {
-    #[error("rocksdb error")]
-    RocksDBError(#[from] RocksErrorDef),
-    #[error("(de)serialization error")]
-    SerializationError(#[from] BincodeErrorDef),
+    #[error("rocksdb error: {0}")]
+    RocksDBError(String),
+    #[error("(de)serialization error: {0}")]
+    SerializationError(String),
     #[error("the column family {0} was not registered with the database")]
     UnregisteredColumn(String),
     #[error("a batch operation can't operate across databases")]
@@ -22,7 +22,7 @@ pub enum TypedStoreError {
 }
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, Error)]
-pub struct RocksErrorDef {
+pub(crate) struct RocksErrorDef {
     message: String,
 }
 
@@ -36,7 +36,7 @@ impl From<RocksError> for RocksErrorDef {
 
 impl From<RocksError> for TypedStoreError {
     fn from(err: RocksError) -> Self {
-        TypedStoreError::RocksDBError(err.into())
+        TypedStoreError::RocksDBError(format!("{}", err))
     }
 }
 
@@ -47,7 +47,7 @@ impl Display for RocksErrorDef {
 }
 
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug, Error)]
-pub enum BincodeErrorDef {
+pub(crate) enum BincodeErrorDef {
     Io(String),
     InvalidUtf8Encoding(String),
     InvalidBoolEncoding(u8),
@@ -108,6 +108,6 @@ impl From<bincode::Error> for BincodeErrorDef {
 
 impl From<bincode::Error> for TypedStoreError {
     fn from(err: bincode::Error) -> Self {
-        TypedStoreError::SerializationError(err.into())
+        TypedStoreError::SerializationError(format!("{}", err))
     }
 }

--- a/typed-store/src/rocks/errors.rs
+++ b/typed-store/src/rocks/errors.rs
@@ -1,19 +1,113 @@
 // Copyright(C) 2022, Mysten Labs
 // SPDX-License-Identifier: Apache-2.0
 
-use bincode::Error as BincodeError;
+use bincode::ErrorKind as BincodeErrorKind;
+
 use rocksdb::Error as RocksError;
+use serde::{Deserialize, Serialize};
+use std::{fmt, fmt::Display};
 use thiserror::Error;
 
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub enum TypedStoreError {
     #[error("rocksdb error")]
-    RocksDBError(#[from] RocksError),
+    RocksDBError(#[from] RocksErrorDef),
     #[error("(de)serialization error")]
-    SerializationError(#[from] BincodeError),
+    SerializationError(#[from] BincodeErrorDef),
     #[error("the column family {0} was not registered with the database")]
     UnregisteredColumn(String),
     #[error("a batch operation can't operate across databases")]
     CrossDBBatch,
+}
+
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, Error)]
+pub struct RocksErrorDef {
+    message: String,
+}
+
+impl From<RocksError> for RocksErrorDef {
+    fn from(err: RocksError) -> Self {
+        RocksErrorDef {
+            message: err.as_ref().to_string(),
+        }
+    }
+}
+
+impl From<RocksError> for TypedStoreError {
+    fn from(err: RocksError) -> Self {
+        TypedStoreError::RocksDBError(err.into())
+    }
+}
+
+impl Display for RocksErrorDef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.message.fmt(formatter)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug, Error)]
+pub enum BincodeErrorDef {
+    Io(String),
+    InvalidUtf8Encoding(String),
+    InvalidBoolEncoding(u8),
+    InvalidCharEncoding,
+    InvalidTagEncoding(usize),
+    DeserializeAnyNotSupported,
+    SizeLimit,
+    SequenceMustHaveLength,
+    Custom(String),
+}
+
+impl fmt::Display for BincodeErrorDef {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            BincodeErrorDef::Io(ref ioerr) => write!(fmt, "io error: {}", ioerr),
+            BincodeErrorDef::InvalidUtf8Encoding(ref e) => {
+                write!(fmt, "{}", e)
+            }
+            BincodeErrorDef::InvalidBoolEncoding(b) => {
+                write!(fmt, "expected 0 or 1, found {}", b)
+            }
+            BincodeErrorDef::InvalidCharEncoding => write!(fmt, "{:?}", self),
+            BincodeErrorDef::InvalidTagEncoding(tag) => {
+                write!(fmt, "found {}", tag)
+            }
+            BincodeErrorDef::SequenceMustHaveLength => write!(fmt, "{:?}", self),
+            BincodeErrorDef::SizeLimit => write!(fmt, "{:?}", self),
+            BincodeErrorDef::DeserializeAnyNotSupported => write!(
+                fmt,
+                "Bincode does not support the serde::Deserializer::deserialize_any method"
+            ),
+            BincodeErrorDef::Custom(ref s) => s.fmt(fmt),
+        }
+    }
+}
+
+impl From<bincode::Error> for BincodeErrorDef {
+    fn from(err: bincode::Error) -> Self {
+        match err.as_ref() {
+            BincodeErrorKind::Io(ioerr) => BincodeErrorDef::Io(ioerr.to_string()),
+            BincodeErrorKind::InvalidUtf8Encoding(utf8err) => {
+                BincodeErrorDef::InvalidUtf8Encoding(utf8err.to_string())
+            }
+            BincodeErrorKind::InvalidBoolEncoding(byte) => {
+                BincodeErrorDef::InvalidBoolEncoding(*byte)
+            }
+            BincodeErrorKind::InvalidCharEncoding => BincodeErrorDef::InvalidCharEncoding,
+            BincodeErrorKind::InvalidTagEncoding(tag) => BincodeErrorDef::InvalidTagEncoding(*tag),
+            BincodeErrorKind::DeserializeAnyNotSupported => {
+                BincodeErrorDef::DeserializeAnyNotSupported
+            }
+            BincodeErrorKind::SizeLimit => BincodeErrorDef::SizeLimit,
+            BincodeErrorKind::SequenceMustHaveLength => BincodeErrorDef::SequenceMustHaveLength,
+            BincodeErrorKind::Custom(str) => BincodeErrorDef::Custom(str.to_owned()),
+        }
+    }
+}
+
+impl From<bincode::Error> for TypedStoreError {
+    fn from(err: bincode::Error) -> Self {
+        TypedStoreError::SerializationError(err.into())
+    }
 }

--- a/typed-store/src/rocks/iter.rs
+++ b/typed-store/src/rocks/iter.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use bincode::Options;
 
-use eyre::Result;
+use super::errors::TypedStoreError;
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::DBRawIteratorMultiThreaded;
@@ -50,7 +50,7 @@ impl<'a, K: Serialize, V> Iter<'a, K, V> {
     /// Skips all the elements that are smaller than the given key,
     /// and either lands on the key or the first one greater than
     /// the key.
-    pub fn skip_to(mut self, key: &K) -> Result<Self> {
+    pub fn skip_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
         let config = bincode::DefaultOptions::new()
             .with_big_endian()
             .with_fixint_encoding();
@@ -61,7 +61,7 @@ impl<'a, K: Serialize, V> Iter<'a, K, V> {
     /// Moves the iterator the element given or
     /// the one prior to it if it does not exist. If there is
     /// no element prior to it, it returns an empty iterator.
-    pub fn skip_prior_to(mut self, key: &K) -> Result<Self> {
+    pub fn skip_prior_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
         let config = bincode::DefaultOptions::new()
             .with_big_endian()
             .with_fixint_encoding();

--- a/typed-store/src/traits.rs
+++ b/typed-store/src/traits.rs
@@ -1,26 +1,27 @@
 // Copyright(C) 2021, Mysten Labs
 // SPDX-License-Identifier: Apache-2.0
-use eyre::Result;
 use serde::{de::DeserializeOwned, Serialize};
+use std::error::Error;
 
 pub trait Map<'a, K, V>
 where
     K: Serialize + DeserializeOwned + ?Sized,
     V: Serialize + DeserializeOwned,
 {
+    type Error: Error;
     type Iterator: Iterator<Item = (K, V)>;
     type Keys: Iterator<Item = K>;
     type Values: Iterator<Item = V>;
 
     /// Returns true if the map contains a value for the specified key.
-    fn contains_key(&self, key: &K) -> Result<bool>;
+    fn contains_key(&self, key: &K) -> Result<bool, Self::Error>;
 
     /// Returns the value for the given key from the map, if it exists.
-    fn get(&self, key: &K) -> Result<Option<V>>;
+    fn get(&self, key: &K) -> Result<Option<V>, Self::Error>;
 
     /// Returns the value for the given key from the map, if it exists
     /// or the given default value if it does not.
-    fn get_or_insert<F: FnOnce() -> V>(&self, key: &K, default: F) -> Result<V> {
+    fn get_or_insert<F: FnOnce() -> V>(&self, key: &K, default: F) -> Result<V, Self::Error> {
         self.get(key).and_then(|optv| match optv {
             Some(v) => Ok(v),
             None => {
@@ -31,10 +32,10 @@ where
     }
 
     /// Inserts the given key-value pair into the map.
-    fn insert(&self, key: &K, value: &V) -> Result<()>;
+    fn insert(&self, key: &K, value: &V) -> Result<(), Self::Error>;
 
     /// Removes the entry for the given key from the map.
-    fn remove(&self, key: &K) -> Result<()>;
+    fn remove(&self, key: &K) -> Result<(), Self::Error>;
 
     /// Returns an iterator visiting each key-value pair in the map.
     fn iter(&'a self) -> Self::Iterator;
@@ -46,5 +47,5 @@ where
     fn values(&'a self) -> Self::Values;
 
     /// Returns a vector of values corresponding to the keys provided.
-    fn multi_get(&self, keys: &[K]) -> Result<Vec<Option<V>>>;
+    fn multi_get(&self, keys: &[K]) -> Result<Vec<Option<V>>, Self::Error>;
 }


### PR DESCRIPTION
TypedStore errors are all coerced into the concrete `anyhow::Error`,  which makes the typed_store crate hard to reuse upstream.

This adds a basic Error type that for now encapsulates errors from either the database or the serializer / deserializer.