### PR TITLE
Added clear function in DBMap

### DIFF
--- a/typed-store/src/rocks/mod.rs
+++ b/typed-store/src/rocks/mod.rs
@@ -289,6 +289,14 @@ where
         Ok(())
     }
 
+    fn len(&self) -> Result<usize, Self::Error> {
+        Ok(self.iter().count())
+    }
+
+    fn is_empty(&self) -> Result<bool, Self::Error> {
+        Ok(self.iter().count() == 0)
+    }
+
     fn iter(&'a self) -> Self::Iterator {
         let mut db_iter = self.rocksdb.raw_iterator_cf(&self.cf());
         db_iter.seek_to_first();

--- a/typed-store/src/rocks/mod.rs
+++ b/typed-store/src/rocks/mod.rs
@@ -289,14 +289,6 @@ where
         Ok(())
     }
 
-    fn len(&self) -> Result<usize, Self::Error> {
-        Ok(self.iter().count())
-    }
-
-    fn is_empty(&self) -> Result<bool, Self::Error> {
-        Ok(self.iter().count() == 0)
-    }
-
     fn iter(&'a self) -> Self::Iterator {
         let mut db_iter = self.rocksdb.raw_iterator_cf(&self.cf());
         db_iter.seek_to_first();

--- a/typed-store/src/rocks/mod.rs
+++ b/typed-store/src/rocks/mod.rs
@@ -283,8 +283,9 @@ where
     }
 
     fn clear(&self) -> Result<(), TypedStoreError> {
-        let del_batch = self.batch().delete_batch(self, self.keys())?;
-        let _ = del_batch.write();
+        let _ = self.rocksdb.drop_cf(&self.cf);
+        self.rocksdb
+            .create_cf(self.cf.clone(), &rocksdb::Options::default())?;
         Ok(())
     }
 

--- a/typed-store/src/rocks/mod.rs
+++ b/typed-store/src/rocks/mod.rs
@@ -283,23 +283,8 @@ where
     }
 
     fn clear(&self) -> Result<(), TypedStoreError> {
-        let config = bincode::DefaultOptions::new()
-            .with_big_endian()
-            .with_fixint_encoding();
-        let num_items = self.iter().count();
-        if num_items == 0 {
-            return Ok(());
-        }
-        let end = config.serialize(&self.iter().last().unwrap().0)?;
-        if num_items > 1 {
-            let start = config.serialize(&self.iter().next().unwrap().0)?;
-            // This deletes all but the last elem
-            let _ = self
-                .rocksdb
-                .delete_range_cf(&self.cf(), start, end.clone())?;
-        }
-        // Finally delete the last elem
-        let _ = self.rocksdb.delete(end)?;
+        let del_batch = self.batch().delete_batch(self, self.keys())?;
+        let _ = del_batch.write();
         Ok(())
     }
 

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -313,3 +313,31 @@ fn test_delete_range() {
     // range operator is not inclusive of to
     assert!(db.contains_key(&100).expect("Failed to query legel key"));
 }
+
+#[test]
+fn test_clear() {
+    let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
+    // Test clear of empty map
+    let _ = db.clear();
+
+    let keys_vals = (0..101).map(|i| (i, i.to_string()));
+    let insert_batch = db
+        .batch()
+        .insert_batch(&db, keys_vals)
+        .expect("Failed to batch insert");
+
+    let _ = insert_batch.write().expect("Failed to execute batch");
+
+    // Check we have multiple entries
+    assert!(db.iter().count() > 1);
+    let _ = db.clear();
+    assert_eq!(db.iter().count(), 0);
+    // Clear again to ensue safety when clearing empty map
+    let _ = db.clear();
+    assert_eq!(db.iter().count(), 0);
+    // Clear with one item
+    let _ = db.insert(&1, &"e".to_string());
+    assert_eq!(db.iter().count(), 1);
+    let _ = db.clear();
+    assert_eq!(db.iter().count(), 0);
+}

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -316,7 +316,8 @@ fn test_delete_range() {
 
 #[test]
 fn test_clear() {
-    let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
+    let db = DBMap::<i32, String>::open(temp_dir(), None, Some("table"))
+        .expect("Failed to open storage");
     // Test clear of empty map
     let _ = db.clear();
 
@@ -332,7 +333,7 @@ fn test_clear() {
     assert!(db.iter().count() > 1);
     let _ = db.clear();
     assert_eq!(db.iter().count(), 0);
-    // Clear again to ensue safety when clearing empty map
+    // Clear again to ensure safety when clearing empty map
     let _ = db.clear();
     assert_eq!(db.iter().count(), 0);
     // Clear with one item

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -342,23 +342,3 @@ fn test_clear() {
     let _ = db.clear();
     assert_eq!(db.iter().count(), 0);
 }
-
-#[test]
-fn test_len() {
-    let db = DBMap::<i32, String>::open(temp_dir(), None, Some("table"))
-        .expect("Failed to open storage");
-    // Test clear of empty map
-    let _ = db.clear();
-
-    let keys_vals = (0..101).map(|i| (i, i.to_string()));
-    let insert_batch = db
-        .batch()
-        .insert_batch(&db, keys_vals)
-        .expect("Failed to batch insert");
-
-    let _ = insert_batch.write().expect("Failed to execute batch");
-    assert_eq!(db.len().unwrap(), 101);
-
-    let _ = db.clear();
-    assert!(db.is_empty().unwrap());
-}

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -342,3 +342,23 @@ fn test_clear() {
     let _ = db.clear();
     assert_eq!(db.iter().count(), 0);
 }
+
+#[test]
+fn test_len() {
+    let db = DBMap::<i32, String>::open(temp_dir(), None, Some("table"))
+        .expect("Failed to open storage");
+    // Test clear of empty map
+    let _ = db.clear();
+
+    let keys_vals = (0..101).map(|i| (i, i.to_string()));
+    let insert_batch = db
+        .batch()
+        .insert_batch(&db, keys_vals)
+        .expect("Failed to batch insert");
+
+    let _ = insert_batch.write().expect("Failed to execute batch");
+    assert_eq!(db.len().unwrap(), 101);
+
+    let _ = db.clear();
+    assert!(db.is_empty().unwrap());
+}

--- a/typed-store/src/traits.rs
+++ b/typed-store/src/traits.rs
@@ -40,6 +40,12 @@ where
     /// Removes every key-value pair from the map
     fn clear(&self) -> Result<(), Self::Error>;
 
+    /// Returns the length of the map
+    fn len(&self) -> Result<usize, Self::Error>;
+
+    /// Returns whether the map is empty
+    fn is_empty(&self) -> Result<bool, Self::Error>;
+
     /// Returns an iterator visiting each key-value pair in the map.
     fn iter(&'a self) -> Self::Iterator;
 

--- a/typed-store/src/traits.rs
+++ b/typed-store/src/traits.rs
@@ -37,6 +37,9 @@ where
     /// Removes the entry for the given key from the map.
     fn remove(&self, key: &K) -> Result<(), Self::Error>;
 
+    /// Removes every key-value pair from the map
+    fn clear(&self) -> Result<(), Self::Error>;
+
     /// Returns an iterator visiting each key-value pair in the map.
     fn iter(&'a self) -> Self::Iterator;
 

--- a/typed-store/src/traits.rs
+++ b/typed-store/src/traits.rs
@@ -40,12 +40,6 @@ where
     /// Removes every key-value pair from the map
     fn clear(&self) -> Result<(), Self::Error>;
 
-    /// Returns the length of the map
-    fn len(&self) -> Result<usize, Self::Error>;
-
-    /// Returns whether the map is empty
-    fn is_empty(&self) -> Result<bool, Self::Error>;
-
     /// Returns an iterator visiting each key-value pair in the map.
     fn iter(&'a self) -> Self::Iterator;
 


### PR DESCRIPTION
Mimicking HashMap::clear to clear all items in a map.
We currently have no clean way to clear a map without getting all keys and then batch deleting the keys.
This PR uses the RocksDB recommended solution via `delete_range`

If this solution checks out, will add other small utility functions such is_empty and len() _[although these can currently be inferred from map.iter().count()]_