### PR TITLE
Iterator extensions

### DIFF
--- a/typed-store/Cargo.toml
+++ b/typed-store/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0.132", features = ["derive"]}
 bincode = "1.3.3"
 tokio = { version = "1.15.0", features = ["sync", "macros", "rt"] }
 thiserror = "1.0.30"
+collectable = "0.0.2"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/typed-store/src/rocks/mod.rs
+++ b/typed-store/src/rocks/mod.rs
@@ -205,9 +205,7 @@ impl DBBatch {
         self.batch.delete_range_cf(&db.cf(), from_buf, to_buf);
         Ok(self)
     }
-}
 
-impl DBBatch {
     /// inserts a range of (key, value) pairs given as an iterator
     #[allow(clippy::map_collect_result_unit)] // we don't want a mutable argument
     pub fn insert_batch<K: Serialize, V: Serialize>(

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -201,6 +201,19 @@ fn test_values() {
 }
 
 #[test]
+fn test_try_extend() {
+    let mut db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
+    let mut keys_vals = (1..100).map(|i| (i, i.to_string()));
+
+    db.try_extend(&mut keys_vals)
+        .expect("Failed to extend the DB with (k, v) pairs");
+    for (k, v) in keys_vals {
+        let val = db.get(&k).expect("Failed to get inserted key");
+        assert_eq!(Some(v), val);
+    }
+}
+
+#[test]
 fn test_insert_batch() {
     let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
     let keys_vals = (1..100).map(|i| (i, i.to_string()));

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -249,10 +249,12 @@ fn test_insert_batch_across_different_db() {
     let rocks = open_cf(temp_dir(), None, &["First_CF", "Second_CF"]).unwrap();
     let rocks2 = open_cf(temp_dir(), None, &["First_CF", "Second_CF"]).unwrap();
 
-    let db_cf_1 = DBMap::reopen(&rocks, Some("First_CF")).expect("Failed to open storage");
+    let db_cf_1: DBMap<i32, String> =
+        DBMap::reopen(&rocks, Some("First_CF")).expect("Failed to open storage");
     let keys_vals_1 = (1..100).map(|i| (i, i.to_string()));
 
-    let db_cf_2 = DBMap::reopen(&rocks2, Some("Second_CF")).expect("Failed to open storage");
+    let db_cf_2: DBMap<i32, String> =
+        DBMap::reopen(&rocks2, Some("Second_CF")).expect("Failed to open storage");
     let keys_vals_2 = (1000..1100).map(|i| (i, i.to_string()));
 
     assert!(db_cf_1
@@ -288,7 +290,8 @@ fn test_delete_batch() {
 
 #[test]
 fn test_delete_range() {
-    let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
+    let db: DBMap<i32, String> =
+        DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
 
     // Note that the last element is (100, "100".to_owned()) here
     let keys_vals = (0..101).map(|i| (i, i.to_string()));


### PR DESCRIPTION
This adds a convenience implementation of `collectable::TryExtend` for `DBMap` and removes unneeded by-value arguments in batch operations.