### PR TITLE
Use bloom filter when checking if key exists

### DIFF
--- a/typed-store/src/rocks/mod.rs
+++ b/typed-store/src/rocks/mod.rs
@@ -241,6 +241,15 @@ where
     type Values = Values<'a, V>;
 
     fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
+        let config = bincode::DefaultOptions::new()
+            .with_big_endian()
+            .with_fixint_encoding();
+        // Try checking the bloom filter
+        if !self.rocksdb.key_may_exist_cf(&self.cf(), &config.serialize(key)?) {
+            // Defintely does not exist
+            return Ok(false);
+        }
+        // Might exist. Do deeper check
         self.get(key).map(|v| v.is_some())
     }
 

--- a/typed-store/src/rocks/mod.rs
+++ b/typed-store/src/rocks/mod.rs
@@ -245,7 +245,10 @@ where
             .with_big_endian()
             .with_fixint_encoding();
         // Try checking the bloom filter
-        if !self.rocksdb.key_may_exist_cf(&self.cf(), &config.serialize(key)?) {
+        if !self
+            .rocksdb
+            .key_may_exist_cf(&self.cf(), &config.serialize(key)?)
+        {
             // Defintely does not exist
             return Ok(false);
         }


### PR DESCRIPTION
RocksDB provides access to it's bloom filter which can be used to check if a key exists in DRAM.
This might save some IO over the current way which uses a potentially wasteful `get` operation