### PR TITLE
feat: introduce reopen macro to reopen multiple column family

### DIFF
--- a/typed-store/src/rocks/mod.rs
+++ b/typed-store/src/rocks/mod.rs
@@ -22,6 +22,7 @@ type DBRawIteratorMultiThreaded<'a> =
     rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>;
 
 /// a helper macro to reopen multiple column families
+///
 /// # Arguments
 ///
 /// * `db` - a reference to a rocks DB object
@@ -31,18 +32,18 @@ type DBRawIteratorMultiThreaded<'a> =
 ///
 /// # Examples
 ///
-/// We open two different column families and we successfully write to them
+/// We successfully open two different column families.
 /// ```
-/// # #[macro_use] extern crate reopen;
+/// # use typed_store::reopen;
 /// # use typed_store::rocks::*;
 /// # use tempfile::tempdir;
 ///
 /// # fn main() {
-/// # const FIRST_CF: &str = "First_CF";
-/// # const SECOND_CF: &str = "Second_CF";
+/// const FIRST_CF: &str = "First_CF";
+/// const SECOND_CF: &str = "Second_CF";
 ///
 /// /// Create the rocks database reference for the desired column families
-/// let rocks = open_cf(temp_dir().unwrap(), None, &[FIRST_CF, SECOND_CF]).unwrap();
+/// let rocks = open_cf(tempdir().unwrap(), None, &[FIRST_CF, SECOND_CF]).unwrap();
 ///
 /// /// Now simply open all the column families for their expected Key-Value types
 /// let (db_cf_1, db_cf_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);

--- a/typed-store/src/rocks/mod.rs
+++ b/typed-store/src/rocks/mod.rs
@@ -48,7 +48,7 @@ type DBRawIteratorMultiThreaded<'a> =
 /// let rocks = open_cf(tempdir().unwrap(), None, &[FIRST_CF, SECOND_CF]).unwrap();
 ///
 /// /// Now simply open all the column families for their expected Key-Value types
-/// let (db_cf_1, db_cf_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
+/// let (db_map_1, db_map_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
 /// # }
 /// ```
 #[macro_export]

--- a/typed-store/src/rocks/mod.rs
+++ b/typed-store/src/rocks/mod.rs
@@ -21,7 +21,9 @@ mod tests;
 type DBRawIteratorMultiThreaded<'a> =
     rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>;
 
-/// a helper macro to reopen multiple column families
+/// A helper macro to reopen multiple column families. The macro returns
+/// a tuple of DBMap structs in the same order that the column families
+/// are defined.
 ///
 /// # Arguments
 ///

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -30,6 +30,22 @@ fn test_reopen() {
 }
 
 #[test]
+fn test_reopen_macro() {
+    const FIRST_CF: &str = "First_CF";
+    const SECOND_CF: &str = "Second_CF";
+
+    let rocks = open_cf(temp_dir(), None, &[FIRST_CF, SECOND_CF]).unwrap();
+
+    let (db_cf_1, db_cf_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
+
+    let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
+    let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
+
+    assert!(db_cf_1.multi_insert(keys_vals_cf1).is_ok());
+    assert!(db_cf_2.multi_insert(keys_vals_cf2).is_ok());
+}
+
+#[test]
 fn test_wrong_reopen() {
     let rocks = open_cf(temp_dir(), None, &["foo", "bar", "baz"]).unwrap();
     let db = DBMap::<u8, u8>::reopen(&rocks, Some("quux"));
@@ -256,22 +272,6 @@ fn test_insert_batch_across_cf() {
         let val = db_cf_2.get(&k).expect("Failed to get inserted key");
         assert_eq!(Some(v), val);
     }
-}
-
-#[test]
-fn test_reopen_macro() {
-    const FIRST_CF: &str = "First_CF";
-    const SECOND_CF: &str = "Second_CF";
-
-    let rocks = open_cf(temp_dir(), None, &[FIRST_CF, SECOND_CF]).unwrap();
-
-    let (db_cf_1, db_cf_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
-
-    let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
-    let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
-
-    assert!(db_cf_1.multi_insert(keys_vals_cf1).is_ok());
-    assert!(db_cf_2.multi_insert(keys_vals_cf2).is_ok());
 }
 
 #[test]

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -36,16 +36,16 @@ fn test_reopen_macro() {
 
     let rocks = open_cf(temp_dir(), None, &[FIRST_CF, SECOND_CF]).unwrap();
 
-    let (db_cf_1, db_cf_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
+    let (db_map_1, db_map_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
 
     let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
     let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
 
-    assert_eq!(db_cf_1.cf, FIRST_CF);
-    assert_eq!(db_cf_2.cf, SECOND_CF);
+    assert_eq!(db_map_1.cf, FIRST_CF);
+    assert_eq!(db_map_2.cf, SECOND_CF);
 
-    assert!(db_cf_1.multi_insert(keys_vals_cf1).is_ok());
-    assert!(db_cf_2.multi_insert(keys_vals_cf2).is_ok());
+    assert!(db_map_1.multi_insert(keys_vals_cf1).is_ok());
+    assert!(db_map_2.multi_insert(keys_vals_cf2).is_ok());
 }
 
 #[test]

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -265,9 +265,7 @@ fn test_reopen_macro() {
 
     let rocks = open_cf(temp_dir(), None, &[FIRST_CF, SECOND_CF]).unwrap();
 
-    reopen!(FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
-
-    let (db_cf_1, db_cf_2) = reopencfs(&rocks);
+    let (db_cf_1, db_cf_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
 
     let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
     let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -41,6 +41,9 @@ fn test_reopen_macro() {
     let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
     let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
 
+    assert_eq!(db_cf_1.cf, FIRST_CF);
+    assert_eq!(db_cf_2.cf, SECOND_CF);
+
     assert!(db_cf_1.multi_insert(keys_vals_cf1).is_ok());
     assert!(db_cf_2.multi_insert(keys_vals_cf2).is_ok());
 }

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -1,3 +1,4 @@
+use crate::reopen;
 // Copyright(C) 2021, Mysten Labs
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
@@ -255,6 +256,24 @@ fn test_insert_batch_across_cf() {
         let val = db_cf_2.get(&k).expect("Failed to get inserted key");
         assert_eq!(Some(v), val);
     }
+}
+
+#[test]
+fn test_reopen_macro() {
+    const FIRST_CF: &str = "First_CF";
+    const SECOND_CF: &str = "Second_CF";
+
+    let rocks = open_cf(temp_dir(), None, &[FIRST_CF, SECOND_CF]).unwrap();
+
+    reopen!(FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
+
+    let (db_cf_1, db_cf_2) = reopencfs(&rocks);
+
+    let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
+    let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
+
+    assert!(db_cf_1.multi_insert(keys_vals_cf1).is_ok());
+    assert!(db_cf_2.multi_insert(keys_vals_cf2).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Resolves #13 

this PR introduces a new macro `reopen`  that acts as a helper to reopen column families and avoid having repeatable code like:

```
let db_cf_1 = DBMap::<u32,u32>::reopen(&rocks, Some("First_CF")).expect("Failed to open storage"); 
let db_cf_2 = DBMap::<u32,u32>::reopen(&rocks, Some("Second_CF")).expect("Failed to open storage"); 
```

I am 100% sure there are other better ways to do it, but that's a way I thought to explore. Honestly, don't know how much more hustle it will save us, but still it's an approach.

The macro basically creates a new function `reopencfs` that handles the column family reopen. The target for me was to make clear the return types of the initialisation function. That was the main challenge for me, to somehow instruct the macro the required column family Key Value types - that's why I ended up on the solution of generating a new function.

Example usage:

```
// call the reopen macro for the required column families 
// and their corresponding Key-Value types
reopen!("cf_1";<String, u32>, "cf_2";<u32, u32>);

// now call the generated function
let (cf_1, cf_2) = reopencfs(&db);
```
