### PR TITLE
Psk improvements

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,7 @@ unlicensed = "deny"
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
     "MIT",
+    "BSD-2-Clause",
     "BSD-3-Clause",
     "CC0-1.0",
     "Apache-2.0",

--- a/rccheck/Cargo.toml
+++ b/rccheck/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0.53"
 ed25519-dalek = "1.0.1"
 ed25519 = { version = "1.3.0", features = ["pkcs8", "alloc", "zeroize"] }
 pkcs8 = { version = "0.8.0", features = ["std"] }
+ouroboros = "0.14.2"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/rccheck/src/lib.rs
+++ b/rccheck/src/lib.rs
@@ -35,6 +35,9 @@ pub(crate) mod test_utils;
 
 pub mod ed25519_certgen;
 
+// Re-export our version of rustls to stave off compatiblity issues
+pub use rustls;
+
 type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];
 static SUPPORTED_SIG_ALGS: SignatureAlgorithms = &[&webpki::ECDSA_P256_SHA256, &webpki::ED25519];
 
@@ -153,8 +156,8 @@ impl<'a> ClientCertVerifier for Psk<'a> {
     }
 
     fn client_auth_root_subjects(&self) -> Option<rustls::DistinguishedNames> {
-        // We can't guarantee subjects before having seen the cert
-        None
+        // We can't guarantee subjects before having seen the cert. This should not be None for compatiblity reasons
+        Some(rustls::DistinguishedNames::new())
     }
 
     // Verifies this is a valid certificate self-signed by the public key we expect(in PSK)


### PR DESCRIPTION
This fixes `Psk`, from a non-allocating structure (for historical reasons not relevant to our purposes) to a regular, allocating one, which wraps a few bytes. 

As a consequence, the lifetime drops off the description of Psk, it becomes trivial to ferry a Psk across threads and give it to rustls to check client certificates with.