### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all -- -D clippy::all -D warnings -D clippy::disallowed_method
+          args: --all --tests -- -D clippy::all -D warnings -D clippy::disallowed_method
 
   rustfmt:
     name: rustfmt

--- a/component/examples/stream_example.rs
+++ b/component/examples/stream_example.rs
@@ -54,6 +54,12 @@ impl MockTcpStream {
     }
 }
 
+impl Default for MockTcpStream {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MockTcpStreamComponent {
     /// This is a function that should run continuously doing some operation, here we are
     /// continuously listening on a mocked TCP Stream. This is ultimately the function that we

--- a/typed-store/Cargo.toml
+++ b/typed-store/Cargo.toml
@@ -8,7 +8,8 @@ repository = "https://github.com/mystenlabs/mysten-infra"
 edition = "2021"
 
 [dependencies]
-rocksdb = "0.18.0"
+# deactivation of bzip2 due to https://github.com/rust-rocksdb/rust-rocksdb/issues/609
+rocksdb = { version = "0.18.0", features = ["snappy", "lz4", "zstd", "zlib"], default-features = false }
 eyre = "0.6.5"
 serde = { version = "1.0.133", features = ["derive"]}
 bincode = "1.3.3"


### PR DESCRIPTION
The most important one is we're hitting an instance of https://github.com/rust-rocksdb/rust-rocksdb/issues/609 in CI `--release` builds of downstream packages.