### PR TITLE
RFC: introduce a Non-conflicting insert operator

### DIFF
--- a/typed-store/src/rocks/mod.rs
+++ b/typed-store/src/rocks/mod.rs
@@ -454,18 +454,11 @@ pub(crate) fn non_conflicting_insert_merge(
     existing_val: Option<&[u8]>,
     operands: &MergeOperands,
 ) -> Option<Vec<u8>> {
-    let nops = operands.len();
-    let mut result: Vec<u8> = Vec::with_capacity(nops);
+    let mut result: Vec<u8> = Vec::new();
     if let Some(v) = existing_val {
-        for e in v {
-            result.push(*e);
-        }
-    } else {
-        for op in operands {
-            for e in op {
-                result.push(*e);
-            }
-        }
+        result.extend(v.iter());
+    } else if let Some(op) = operands.into_iter().next() {
+        result.extend(op.iter());
     }
     Some(result)
 }

--- a/typed-store/src/rocks/tests.rs
+++ b/typed-store/src/rocks/tests.rs
@@ -140,6 +140,25 @@ fn test_non_conflicting_insert() {
         db.get(&23456).expect("Failed to get")
     );
 
+    // more shenanigans with the WAL: several successive operands that work
+    db.non_conflicting_insert(&23456, &"23456".to_string())
+        .expect("Failed to non-conflicting insert");
+    db.non_conflicting_insert(&23456, &"23456".to_string())
+        .expect("Failed to non-conflicting insert");
+    db.non_conflicting_insert(&23456, &"23456".to_string())
+        .expect("Failed to non-conflicting insert");
+    db.non_conflicting_insert(&123456789, &"23456".to_string())
+        .expect("Failed to non-conflicting insert");
+    db.non_conflicting_insert(&123456789, &"23456".to_string())
+        .expect("Failed to non-conflicting insert");
+    db.non_conflicting_insert(&123456789, &"23456".to_string())
+        .expect("Failed to non-conflicting insert");
+
+    assert_eq!(
+        Some("23456".to_string()),
+        db.get(&23456).expect("Failed to get")
+    );
+
     assert_eq!(
         Some("123456789".to_string()),
         db.get(&123456789).expect("Failed to get")


### PR DESCRIPTION
This :
- demonstrates the use of a merge operator to implement a "weak insert" (insert on empty-or-equal).

This could:
- be used in a try-and-check logic with a get/multi-get to see if a batch of operations have all performed atomically,
- offer a limited substitute to an undefinable CAS operation on the DB.

This could not:
- implement an across-keys all-or-nothing operation, as any merge operator runs independent read-modify-write operations for each key.

TODO:
- [ ] make the operator opt-in rather than by-default,
- [ ] use `pre` crate to make user certify they installed the merge operator they expect at point of use,
- [ ] open the API to let users customize merge operators themselves: 
- ~demo multiplexing of merge operators~