### PR TITLE
chore: use a caching install

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,9 +112,9 @@ jobs:
           toolchain: nightly
           override: true
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/install@v0.1
+      - name: Install cargo-udeps, and cache the binary
+        uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-udeps
-          version: latest
       - name: run cargo-udeps
         run: cargo +nightly udeps

--- a/telemetry_subscribers/examples/easy-init.rs
+++ b/telemetry_subscribers/examples/easy-init.rs
@@ -8,7 +8,7 @@ fn main() {
         service_name: "my_app".into(),
         ..Default::default()
     };
-    let guard = telemetry_subscribers::init(config);
+    let _guard = telemetry_subscribers::init(config);
 
     info!(a = 1, "This will be INFO.");
     debug!(a = 2, "This will be DEBUG.");


### PR DESCRIPTION
https://github.com/baptiste0928/cargo-install caches the binary after compilation, for speed of repeated execution