### PR TITLE
Support for generating chrome trace output

### DIFF
--- a/telemetry_subscribers/Cargo.toml
+++ b/telemetry_subscribers/Cargo.toml
@@ -19,9 +19,11 @@ tracing-opentelemetry = { version = "0.17", optional = true }
 opentelemetry = { version = "*", features = ["rt-tokio"], optional = true }
 opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"], optional = true }
 console-subscriber = { version = "0.1.3", optional = true }
+tracing-chrome = { version = "0.5.0", optional = true }
 
 [features]
 default = ["jaeger"]
 tokio-console = ["console-subscriber"]
 json = ["tracing-bunyan-formatter"]
 jaeger = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-jaeger"]
+chrome = ["tracing-chrome"]


### PR DESCRIPTION
Can be viewed in the chrome trace viewer via chrome://tracing -> load

Much faster to navigate and explore than Jaeger when you're trying to debug stuff.

<img width="971" alt="image" src="https://user-images.githubusercontent.com/103447440/163280518-6a4b53f8-de7b-4502-8738-2eb0889fbe5c.png">
