### PR TITLE
mysten-network: add common networking utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/component",
+    "crates/mysten-network",
     "crates/name-variant",
     "crates/rccheck",
     "crates/telemetry-subscribers",

--- a/crates/mysten-network/Cargo.toml
+++ b/crates/mysten-network/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.56"
 bincode = "1.3.3"
 bytes = "1.1.0"
 multiaddr = "0.14.0"
+futures = "0.3.21"
 serde = "1.0.137"
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/crates/mysten-network/Cargo.toml
+++ b/crates/mysten-network/Cargo.toml
@@ -11,7 +11,7 @@ bincode = "1.3.3"
 bytes = "1.1.0"
 multiaddr = "0.14.0"
 futures = "0.3.21"
-serde = "1.0.137"
+serde = { version = "1.0.137", features = ["derive"] }
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { version = "0.7", features = ["transport"] }

--- a/crates/mysten-network/Cargo.toml
+++ b/crates/mysten-network/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mysten-network"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0.56"
+bincode = "1.3.3"
+bytes = "1.1.0"
+multiaddr = "0.14.0"
+serde = "1.0.137"
+tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic = { version = "0.7", features = ["transport"] }
+tonic-health = "0.6.0"
+tower = { version = "0.4", features = ["full"] }

--- a/crates/mysten-network/src/client.rs
+++ b/crates/mysten-network/src/client.rs
@@ -1,0 +1,167 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    config::Config,
+    multiaddr::{parse_dns, parse_ip4, parse_ip6, parse_unix},
+};
+use anyhow::{anyhow, Context, Result};
+use multiaddr::{Multiaddr, Protocol};
+use std::path::PathBuf;
+use tonic::transport::{Channel, Endpoint, Uri};
+
+pub async fn connect(address: &Multiaddr) -> Result<Channel> {
+    let channel = endpoint_from_multiaddr(address)?.connect().await?;
+    Ok(channel)
+}
+
+pub fn connect_lazy(address: &Multiaddr) -> Result<Channel> {
+    let channel = endpoint_from_multiaddr(address)?.connect_lazy();
+    Ok(channel)
+}
+
+pub(crate) async fn connect_with_config(address: &Multiaddr, config: &Config) -> Result<Channel> {
+    let channel = endpoint_from_multiaddr(address)?
+        .apply_config(config)
+        .connect()
+        .await?;
+    Ok(channel)
+}
+
+pub(crate) fn connect_lazy_with_config(address: &Multiaddr, config: &Config) -> Result<Channel> {
+    let channel = endpoint_from_multiaddr(address)?
+        .apply_config(config)
+        .connect_lazy();
+    Ok(channel)
+}
+
+fn endpoint_from_multiaddr(addr: &Multiaddr) -> Result<MyEndpoint> {
+    let mut iter = addr.iter();
+
+    let channel = match iter.next().ok_or_else(|| anyhow!("address is empty"))? {
+        Protocol::Dns(_) => {
+            let (dns_name, tcp_port, http_or_https) = parse_dns(addr)?;
+            let uri = format!("{http_or_https}://{dns_name}:{tcp_port}");
+            MyEndpoint::try_from_uri(uri)?
+        }
+        Protocol::Ip4(_) => {
+            let (socket_addr, http_or_https) = parse_ip4(addr)?;
+            let uri = format!("{http_or_https}://{socket_addr}");
+            MyEndpoint::try_from_uri(uri)?
+        }
+        Protocol::Ip6(_) => {
+            let (socket_addr, http_or_https) = parse_ip6(addr)?;
+            let uri = format!("{http_or_https}://{socket_addr}");
+            MyEndpoint::try_from_uri(uri)?
+        }
+        // Protocol::Memory(_) => todo!(),
+        #[cfg(unix)]
+        Protocol::Unix(_) => {
+            let (path, http_or_https) = parse_unix(addr)?;
+            let uri = format!("{http_or_https}://localhost");
+            MyEndpoint::try_from_uri(uri)?.with_uds_connector(path.as_ref().into())
+        }
+        unsupported => return Err(anyhow!("unsupported protocol {unsupported}")),
+    };
+
+    Ok(channel)
+}
+
+struct MyEndpoint {
+    endpoint: Endpoint,
+    uds_connector: Option<PathBuf>,
+}
+
+impl MyEndpoint {
+    fn new(endpoint: Endpoint) -> Self {
+        Self {
+            endpoint,
+            uds_connector: None,
+        }
+    }
+
+    fn try_from_uri(uri: String) -> Result<Self> {
+        let uri: tonic::transport::Uri = uri
+            .parse()
+            .with_context(|| format!("unable to create Uri from '{uri}'"))?;
+        let endpoint = Endpoint::from(uri);
+        Ok(Self::new(endpoint))
+    }
+
+    fn with_uds_connector(self, path: PathBuf) -> Self {
+        Self {
+            endpoint: self.endpoint,
+            uds_connector: Some(path),
+        }
+    }
+
+    fn apply_config(mut self, config: &Config) -> Self {
+        self.endpoint = apply_config_to_endpoint(config, self.endpoint);
+        self
+    }
+
+    fn connect_lazy(self) -> Channel {
+        if let Some(path) = self.uds_connector {
+            self.endpoint
+                .connect_with_connector_lazy(tower::service_fn(move |_: Uri| {
+                    let path = path.clone();
+
+                    // Connect to a Uds socket
+                    tokio::net::UnixStream::connect(path)
+                }))
+        } else {
+            self.endpoint.connect_lazy()
+        }
+    }
+
+    async fn connect(self) -> Result<Channel> {
+        if let Some(path) = self.uds_connector {
+            self.endpoint
+                .connect_with_connector(tower::service_fn(move |_: Uri| {
+                    let path = path.clone();
+
+                    // Connect to a Uds socket
+                    tokio::net::UnixStream::connect(path)
+                }))
+                .await
+                .map_err(Into::into)
+        } else {
+            self.endpoint.connect().await.map_err(Into::into)
+        }
+    }
+}
+
+fn apply_config_to_endpoint(config: &Config, mut endpoint: Endpoint) -> Endpoint {
+    if let Some(limit) = config.concurrency_limit_per_connection {
+        endpoint = endpoint.concurrency_limit(limit);
+    }
+
+    if let Some(timeout) = config.request_timeout {
+        endpoint = endpoint.timeout(timeout);
+    }
+
+    if let Some(timeout) = config.connect_timeout {
+        endpoint = endpoint.connect_timeout(timeout);
+    }
+
+    if let Some(tcp_nodelay) = config.tcp_nodelay {
+        endpoint = endpoint.tcp_nodelay(tcp_nodelay);
+    }
+
+    if let Some(http2_keepalive_interval) = config.http2_keepalive_interval {
+        endpoint = endpoint.http2_keep_alive_interval(http2_keepalive_interval);
+    }
+
+    if let Some(http2_keepalive_timeout) = config.http2_keepalive_timeout {
+        endpoint = endpoint.keep_alive_timeout(http2_keepalive_timeout);
+    }
+
+    if let Some((limit, duration)) = config.rate_limit {
+        endpoint = endpoint.rate_limit(limit, duration);
+    }
+
+    endpoint
+        .initial_stream_window_size(config.http2_initial_stream_window_size)
+        .initial_connection_window_size(config.http2_initial_connection_window_size)
+        .tcp_keepalive(config.tcp_keepalive)
+}

--- a/crates/mysten-network/src/codec.rs
+++ b/crates/mysten-network/src/codec.rs
@@ -1,0 +1,68 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use bytes::{Buf, BufMut};
+use std::marker::PhantomData;
+use tonic::{
+    codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder},
+    Status,
+};
+
+#[derive(Debug)]
+pub struct BincodeEncoder<T>(PhantomData<T>);
+
+impl<T: serde::Serialize> Encoder for BincodeEncoder<T> {
+    type Item = T;
+    type Error = Status;
+
+    fn encode(&mut self, item: Self::Item, buf: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
+        bincode::serialize_into(buf.writer(), &item).map_err(|e| Status::internal(e.to_string()))
+    }
+}
+
+#[derive(Debug)]
+pub struct BincodeDecoder<U>(PhantomData<U>);
+
+impl<U: serde::de::DeserializeOwned> Decoder for BincodeDecoder<U> {
+    type Item = U;
+    type Error = Status;
+
+    fn decode(&mut self, buf: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
+        if !buf.has_remaining() {
+            return Ok(None);
+        }
+
+        let item: Self::Item =
+            bincode::deserialize_from(buf.reader()).map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Some(item))
+    }
+}
+
+/// A [`Codec`] that implements `application/grpc+bincode` via the serde library.
+#[derive(Debug, Clone)]
+pub struct BincodeCodec<T, U>(PhantomData<(T, U)>);
+
+impl<T, U> Default for BincodeCodec<T, U> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T, U> Codec for BincodeCodec<T, U>
+where
+    T: serde::Serialize + Send + 'static,
+    U: serde::de::DeserializeOwned + Send + 'static,
+{
+    type Encode = T;
+    type Decode = U;
+    type Encoder = BincodeEncoder<T>;
+    type Decoder = BincodeDecoder<U>;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        BincodeEncoder(PhantomData)
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        BincodeDecoder(PhantomData)
+    }
+}

--- a/crates/mysten-network/src/config.rs
+++ b/crates/mysten-network/src/config.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    client::{connect_lazy_with_config, connect_with_config},
+    server::ServerBuilder,
+};
+use anyhow::Result;
+use multiaddr::Multiaddr;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tonic::transport::Channel;
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct Config {
+    /// Set the concurrency limit applied to on requests inbound per connection.
+    pub concurrency_limit_per_connection: Option<usize>,
+
+    /// Set a timeout for all request handlers.
+    pub request_timeout: Option<Duration>,
+
+    /// Set a timeout for establishing an outbound connection.
+    pub connect_timeout: Option<Duration>,
+
+    /// Sets the SETTINGS_INITIAL_WINDOW_SIZE option for HTTP2 stream-level flow control.
+    /// Default is 65,535
+    pub http2_initial_stream_window_size: Option<u32>,
+
+    /// Sets the max connection-level flow control for HTTP2
+    ///
+    /// Default is 65,535
+    pub http2_initial_connection_window_size: Option<u32>,
+
+    /// Sets the SETTINGS_MAX_CONCURRENT_STREAMS option for HTTP2 connections.
+    ///
+    /// Default is no limit (None).
+    pub http2_max_concurrent_streams: Option<u32>,
+
+    /// Set whether TCP keepalive messages are enabled on accepted connections.
+    ///
+    /// If None is specified, keepalive is disabled, otherwise the duration specified will be the
+    /// time to remain idle before sending TCP keepalive probes.
+    ///
+    /// Default is no keepalive (None)
+    pub tcp_keepalive: Option<Duration>,
+
+    /// Set the value of TCP_NODELAY option for accepted connections. Enabled by default.
+    pub tcp_nodelay: Option<bool>,
+
+    /// Set whether HTTP2 Ping frames are enabled on accepted connections.
+    ///
+    /// If None is specified, HTTP2 keepalive is disabled, otherwise the duration specified will be
+    /// the time interval between HTTP2 Ping frames. The timeout for receiving an acknowledgement
+    /// of the keepalive ping can be set with http2_keepalive_timeout.
+    ///
+    /// Default is no HTTP2 keepalive (None)
+    pub http2_keepalive_interval: Option<Duration>,
+
+    /// Sets a timeout for receiving an acknowledgement of the keepalive ping.
+    ///
+    /// If the ping is not acknowledged within the timeout, the connection will be closed. Does nothing
+    /// if http2_keep_alive_interval is disabled.
+    ///
+    /// Default is 20 seconds.
+    pub http2_keepalive_timeout: Option<Duration>,
+
+    // Only affects servers
+    pub load_shed: Option<bool>,
+
+    /// Only affects clients
+    pub rate_limit: Option<(u64, Duration)>,
+
+    // Only affects servers
+    pub global_concurrency_limit: Option<usize>,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn server_builder(&self) -> ServerBuilder {
+        ServerBuilder::from_config(self)
+    }
+
+    pub async fn connect(&self, addr: &Multiaddr) -> Result<Channel> {
+        connect_with_config(addr, self).await
+    }
+
+    pub fn connect_lazy(&self, addr: &Multiaddr) -> Result<Channel> {
+        connect_lazy_with_config(addr, self)
+    }
+}

--- a/crates/mysten-network/src/lib.rs
+++ b/crates/mysten-network/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod client;
+pub mod codec;
+pub mod config;
+mod multiaddr;
+pub mod server;

--- a/crates/mysten-network/src/multiaddr.rs
+++ b/crates/mysten-network/src/multiaddr.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use multiaddr::{Multiaddr, Protocol};
+use std::{
+    borrow::Cow,
+    net::{IpAddr, SocketAddr},
+};
+
+pub(crate) fn parse_tcp<'a, T: Iterator<Item = Protocol<'a>>>(protocols: &mut T) -> Result<u16> {
+    if let Protocol::Tcp(port) = protocols
+        .next()
+        .ok_or_else(|| anyhow!("unexpected end of multiaddr"))?
+    {
+        Ok(port)
+    } else {
+        Err(anyhow!("expected tcp protocol"))
+    }
+}
+
+pub(crate) fn parse_http_https<'a, T: Iterator<Item = Protocol<'a>>>(
+    protocols: &mut T,
+) -> Result<&'static str> {
+    match protocols
+        .next()
+        .ok_or_else(|| anyhow!("unexpected end of multiaddr"))?
+    {
+        Protocol::Http => Ok("http"),
+        Protocol::Https => Ok("https"),
+        _ => Err(anyhow!("expected http/https protocol")),
+    }
+}
+
+pub(crate) fn parse_end<'a, T: Iterator<Item = Protocol<'a>>>(protocols: &mut T) -> Result<()> {
+    if protocols.next().is_none() {
+        Ok(())
+    } else {
+        Err(anyhow!("expected end of multiaddr"))
+    }
+}
+
+// Parse a full /dns/-/tcp/-/{http,https} address
+pub(crate) fn parse_dns(address: &Multiaddr) -> Result<(Cow<'_, str>, u16, &'static str)> {
+    let mut iter = address.iter();
+
+    let dns_name = match iter
+        .next()
+        .ok_or_else(|| anyhow!("unexpected end of multiaddr"))?
+    {
+        Protocol::Dns(dns_name) => dns_name,
+        other => return Err(anyhow!("expected dns found {other}")),
+    };
+    let tcp_port = parse_tcp(&mut iter)?;
+    let http_or_https = parse_http_https(&mut iter)?;
+    parse_end(&mut iter)?;
+    Ok((dns_name, tcp_port, http_or_https))
+}
+
+// Parse a full /ip4/-/tcp/-/{http,https} address
+pub(crate) fn parse_ip4(address: &Multiaddr) -> Result<(SocketAddr, &'static str)> {
+    let mut iter = address.iter();
+
+    let ip_addr = match iter
+        .next()
+        .ok_or_else(|| anyhow!("unexpected end of multiaddr"))?
+    {
+        Protocol::Ip4(ip4_addr) => IpAddr::V4(ip4_addr),
+        other => return Err(anyhow!("expected ip4 found {other}")),
+    };
+    let tcp_port = parse_tcp(&mut iter)?;
+    let http_or_https = parse_http_https(&mut iter)?;
+    parse_end(&mut iter)?;
+    let socket_addr = SocketAddr::new(ip_addr, tcp_port);
+
+    Ok((socket_addr, http_or_https))
+}
+
+// Parse a full /ip6/-/tcp/-/{http,https} address
+pub(crate) fn parse_ip6(address: &Multiaddr) -> Result<(SocketAddr, &'static str)> {
+    let mut iter = address.iter();
+
+    let ip_addr = match iter
+        .next()
+        .ok_or_else(|| anyhow!("unexpected end of multiaddr"))?
+    {
+        Protocol::Ip6(ip6_addr) => IpAddr::V6(ip6_addr),
+        other => return Err(anyhow!("expected ip6 found {other}")),
+    };
+    let tcp_port = parse_tcp(&mut iter)?;
+    let http_or_https = parse_http_https(&mut iter)?;
+    parse_end(&mut iter)?;
+    let socket_addr = SocketAddr::new(ip_addr, tcp_port);
+
+    Ok((socket_addr, http_or_https))
+}
+
+// Parse a full /unix/-/{http,https} address
+#[cfg(unix)]
+pub(crate) fn parse_unix(address: &Multiaddr) -> Result<(Cow<'_, str>, &'static str)> {
+    let mut iter = address.iter();
+
+    let path = match iter
+        .next()
+        .ok_or_else(|| anyhow!("unexpected end of multiaddr"))?
+    {
+        Protocol::Unix(path) => path,
+        other => return Err(anyhow!("expected unix found {other}")),
+    };
+    let http_or_https = parse_http_https(&mut iter)?;
+    parse_end(&mut iter)?;
+
+    Ok((path, http_or_https))
+}

--- a/crates/mysten-network/src/server.rs
+++ b/crates/mysten-network/src/server.rs
@@ -1,0 +1,201 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    config::Config,
+    multiaddr::{parse_dns, parse_ip4, parse_ip6, parse_unix},
+};
+use anyhow::{anyhow, Result};
+use multiaddr::{Multiaddr, Protocol};
+use std::{convert::Infallible, net::SocketAddr};
+use tokio::net::{TcpListener, ToSocketAddrs, UnixListener};
+use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
+use tonic::{
+    body::BoxBody,
+    codegen::{
+        http::{Request, Response},
+        BoxFuture,
+    },
+    transport::{server::Router, Body, NamedService},
+};
+use tower::{
+    layer::util::{Identity, Stack},
+    limit::GlobalConcurrencyLimitLayer,
+    load_shed::LoadShedLayer,
+    util::Either,
+    Service, ServiceBuilder,
+};
+
+pub struct ServerBuilder {
+    router: Router<WrapperService>,
+    health_reporter: tonic_health::server::HealthReporter,
+}
+
+type WrapperService = Stack<
+    Stack<
+        Either<LoadShedLayer, Identity>,
+        Stack<Either<GlobalConcurrencyLimitLayer, Identity>, Identity>,
+    >,
+    Identity,
+>;
+
+impl ServerBuilder {
+    pub fn from_config(config: &Config) -> Self {
+        let mut builder = tonic::transport::server::Server::builder();
+
+        if let Some(limit) = config.concurrency_limit_per_connection {
+            builder = builder.concurrency_limit_per_connection(limit);
+        }
+
+        if let Some(timeout) = config.request_timeout {
+            builder = builder.timeout(timeout);
+        }
+
+        if let Some(tcp_nodelay) = config.tcp_nodelay {
+            builder = builder.tcp_nodelay(tcp_nodelay);
+        }
+
+        let load_shed = if config.load_shed.unwrap_or_default() {
+            Some(tower::load_shed::LoadShedLayer::new())
+        } else {
+            None
+        };
+
+        let global_concurrency_limit = config
+            .global_concurrency_limit
+            .map(tower::limit::GlobalConcurrencyLimitLayer::new);
+
+        let layer = ServiceBuilder::new()
+            .option_layer(global_concurrency_limit)
+            .option_layer(load_shed)
+            .into_inner();
+
+        let (health_reporter, health_service) = tonic_health::server::health_reporter();
+        let router = builder
+            .initial_stream_window_size(config.http2_initial_stream_window_size)
+            .initial_connection_window_size(config.http2_initial_connection_window_size)
+            .http2_keepalive_interval(config.http2_keepalive_interval)
+            .http2_keepalive_timeout(config.http2_keepalive_timeout)
+            .max_concurrent_streams(config.http2_max_concurrent_streams)
+            .tcp_keepalive(config.tcp_keepalive)
+            .layer(layer)
+            .add_service(health_service);
+
+        Self {
+            router,
+            health_reporter,
+        }
+    }
+
+    pub fn health_reporter(&self) -> tonic_health::server::HealthReporter {
+        self.health_reporter.clone()
+    }
+
+    /// Add a new service to this Server.
+    pub fn add_service<S>(mut self, svc: S) -> Self
+    where
+        S: Service<Request<Body>, Response = Response<BoxBody>, Error = Infallible>
+            + NamedService
+            + Clone
+            + Send
+            + 'static,
+        S::Future: Send + 'static,
+    {
+        self.router = self.router.add_service(svc);
+        self
+    }
+
+    pub async fn bind(self, addr: &Multiaddr) -> Result<Server> {
+        let mut iter = addr.iter();
+
+        let (local_addr, server): (Multiaddr, BoxFuture<(), tonic::transport::Error>) =
+            match iter.next().ok_or_else(|| anyhow!("malformed addr"))? {
+                Protocol::Dns(_) => {
+                    let (dns_name, tcp_port, _http_or_https) = parse_dns(addr)?;
+                    let (local_addr, incoming) =
+                        tcp_listener_and_update_multiaddr(addr, (dns_name.as_ref(), tcp_port))
+                            .await?;
+                    let server = Box::pin(self.router.serve_with_incoming(incoming));
+                    (local_addr, server)
+                }
+                Protocol::Ip4(_) => {
+                    let (socket_addr, _http_or_https) = parse_ip4(addr)?;
+                    let (local_addr, incoming) =
+                        tcp_listener_and_update_multiaddr(addr, socket_addr).await?;
+                    let server = Box::pin(self.router.serve_with_incoming(incoming));
+                    (local_addr, server)
+                }
+                Protocol::Ip6(_) => {
+                    let (socket_addr, _http_or_https) = parse_ip6(addr)?;
+                    let (local_addr, incoming) =
+                        tcp_listener_and_update_multiaddr(addr, socket_addr).await?;
+                    let server = Box::pin(self.router.serve_with_incoming(incoming));
+                    (local_addr, server)
+                }
+                // Protocol::Memory(_) => todo!(),
+                #[cfg(unix)]
+                Protocol::Unix(_) => {
+                    let (path, _http_or_https) = parse_unix(addr)?;
+                    let uds = UnixListener::bind(path.as_ref())?;
+                    let uds_stream = UnixListenerStream::new(uds);
+                    let local_addr = addr.to_owned();
+                    let server = Box::pin(self.router.serve_with_incoming(uds_stream));
+                    (local_addr, server)
+                }
+                unsupported => return Err(anyhow!("unsupported protocol {unsupported}")),
+            };
+
+        Ok(Server {
+            server,
+            local_addr,
+            health_reporter: self.health_reporter,
+        })
+    }
+}
+
+async fn tcp_listener_and_update_multiaddr<T: ToSocketAddrs>(
+    address: &Multiaddr,
+    socket_addr: T,
+) -> Result<(Multiaddr, TcpListenerStream)> {
+    let (local_addr, incoming) = tcp_listener(socket_addr).await?;
+    let local_addr = update_tcp_port_in_multiaddr(address, local_addr.port());
+    Ok((local_addr, incoming))
+}
+
+async fn tcp_listener<T: ToSocketAddrs>(address: T) -> Result<(SocketAddr, TcpListenerStream)> {
+    let listener = TcpListener::bind(address).await?;
+    let local_addr = listener.local_addr()?;
+    let incoming = TcpListenerStream::new(listener);
+    Ok((local_addr, incoming))
+}
+
+pub struct Server {
+    server: BoxFuture<(), tonic::transport::Error>,
+    local_addr: Multiaddr,
+    health_reporter: tonic_health::server::HealthReporter,
+}
+
+impl Server {
+    pub async fn serve(self) -> Result<(), tonic::transport::Error> {
+        self.server.await
+    }
+
+    pub fn local_addr(&self) -> &Multiaddr {
+        &self.local_addr
+    }
+
+    pub fn health_reporter(&self) -> tonic_health::server::HealthReporter {
+        self.health_reporter.clone()
+    }
+}
+
+fn update_tcp_port_in_multiaddr(addr: &Multiaddr, port: u16) -> Multiaddr {
+    addr.replace(1, |protocol| {
+        if let Protocol::Tcp(_) = protocol {
+            Some(Protocol::Tcp(port))
+        } else {
+            panic!("expected tcp protocol at index 1");
+        }
+    })
+    .expect("tcp protocol at index 1")
+}


### PR DESCRIPTION
    mysten-network: add common networking utilities

    This adds the `mysten-network` crate which can be used to house common
    networking tools across mysten repos. In particular this currently
    includes:
    - A tonic Codec for the bincode format.
    - Utilites and configuration for building tonic servers or clients using
      the `multiaddr` format.

    Supported multiaddr protocol stacks are:
    - dns/tcp/{http,https}
    - ip4/tcp/{http,https}
    - ip6/tcp/{http,https}
    - unix/{http,https}