### PR TITLE
[CI] Publish Rust docs to Github-pages in CI

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -18,9 +18,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: beta # temporarily use beta till 'instrument-coverage' stabilizes in 1.60
-          profile: default
-          override: true
           components: llvm-tools-preview
       # Enable caching of the 'librocksdb-sys' crate by additionally caching the
       # 'librocksdb-sys' src directory which is managed by cargo

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: Continuous Integration - Docs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  workflow_dispatch:
+
+jobs:
+  docs:
+    name: Generate crate documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Generate documentation
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
+        with:
+          command: doc
+          args: --workspace --no-deps
+
+      - name: Deploy documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc

--- a/crates/rccheck/Cargo.toml
+++ b/crates/rccheck/Cargo.toml
@@ -17,7 +17,7 @@ x509-parser = "0.13.0"
 rcgen = "0.9.2"
 anyhow = "1.0.53"
 ed25519-dalek = "1.0.1"
-ed25519 = { version = "1.3.0", features = ["pkcs8", "alloc", "zeroize"] }
+ed25519 = { version = "=1.3.0", features = ["pkcs8", "alloc", "zeroize"] }
 pkcs8 = { version = "0.8.0", features = ["std"] }
 ouroboros = "0.15.0"
 


### PR DESCRIPTION
This job publishes the rust doc on Github pages by running cargo doc in CI.

@bmwill will no doubt lament my tendency to add yet another rust version to the CI cache (though I made the overall number constant)


successful run:
https://github.com/huitseeker/mysten-infra/runs/6360043578?check_suite_focus=true
result:
https://github.com/huitseeker/mysten-infra/tree/gh-pages

render: I would have to do a custom CNAME, since I use the GH pages functionality elsewhere, but you can pull the branch locally and serve it from your laptop.