### PR TITLE
tracing: send logging to stderr instead of stdout by default

### DIFF
--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -8,14 +8,12 @@ repository = "https://github.com/mystenlabs/mysten-infra"
 edition = "2021"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 tokio = { version = "1.15.0", features = ["sync", "macros", "rt", "rt-multi-thread"] }
 tracing = { version = "0.1.31", features = ["log"] }
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3.11", features = ["time", "registry", "env-filter"] }
-tracing-bunyan-formatter = { version = "0.3", optional = true }
+tracing-bunyan-formatter = { version = "0.3" }
 tracing-opentelemetry = { version = "0.17", optional = true }
 opentelemetry = { version = "*", features = ["rt-tokio"], optional = true }
 opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"], optional = true }
@@ -24,8 +22,7 @@ tracing-chrome = { version = "0.6.0", optional = true }
 once_cell = "1.11.0"
 
 [features]
-default = ["jaeger"]
+default = ["jaeger", "tokio-console", "chrome"]
 tokio-console = ["console-subscriber"]
-json = ["tracing-bunyan-formatter"]
 jaeger = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-jaeger"]
 chrome = ["tracing-chrome"]

--- a/crates/telemetry-subscribers/examples/easy-init.rs
+++ b/crates/telemetry-subscribers/examples/easy-init.rs
@@ -4,11 +4,9 @@
 use tracing::{debug, info, warn};
 
 fn main() {
-    let config = telemetry_subscribers::TelemetryConfig {
-        service_name: "my_app".into(),
-        ..Default::default()
-    };
-    let _guard = telemetry_subscribers::init(config);
+    let _guard = telemetry_subscribers::TelemetryConfig::new("my_app")
+        .with_env()
+        .init();
 
     info!(a = 1, "This will be INFO.");
     debug!(a = 2, "This will be DEBUG.");

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -75,7 +75,7 @@ fn get_output(config: &TelemetryConfig) -> (NonBlocking, WorkerGuard) {
         let file_appender = tracing_appender::rolling::daily("", logfile_prefix);
         tracing_appender::non_blocking(file_appender)
     } else {
-        tracing_appender::non_blocking(std::io::stdout())
+        tracing_appender::non_blocking(std::io::stderr())
     }
 }
 


### PR DESCRIPTION
In many cases, e.g. cli tools like the wallet, a tool may want to print
out some useful information to stdout. Today we currently log to stdout
which makes it very difficult to distinguish between output we want the
user to actually use and log messages. In order to address this this
patch changes our logging infrastructure to log to stderr by default
instead of stdout.