### PR TITLE
Remove colors from log output when stdout is not tty; remove useless log messages

### DIFF
--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -20,6 +20,7 @@ opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"], optional = t
 console-subscriber = { version = "0.1.3", optional = true }
 tracing-chrome = { version = "0.6.0", optional = true }
 once_cell = "1.11.0"
+crossterm = "0.23"
 
 [features]
 default = ["jaeger", "tokio-console", "chrome"]

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -197,7 +197,7 @@ impl DBBatch {
     }
 
     /// Consume the batch and write its operations to the database
-    #[instrument(level = "debug", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err)]
     pub fn write(self) -> Result<(), TypedStoreError> {
         self.rocksdb.write(self.batch)?;
         Ok(())
@@ -276,7 +276,7 @@ where
     type Keys = Keys<'a, K>;
     type Values = Values<'a, V>;
 
-    #[instrument(level = "debug", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err)]
     fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
         let key_buf = be_fix_int_ser(key)?;
         // [`rocksdb::DBWithThreadMode::key_may_exist_cf`] can have false positives,
@@ -285,7 +285,7 @@ where
             && self.rocksdb.get_pinned_cf(&self.cf(), &key_buf)?.is_some())
     }
 
-    #[instrument(level = "debug", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err)]
     fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
         let key_buf = be_fix_int_ser(key)?;
         let res = self.rocksdb.get_pinned_cf(&self.cf(), &key_buf)?;
@@ -295,7 +295,7 @@ where
         }
     }
 
-    #[instrument(level = "debug", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err)]
     fn insert(&self, key: &K, value: &V) -> Result<(), TypedStoreError> {
         let key_buf = be_fix_int_ser(key)?;
         let value_buf = bincode::serialize(value)?;
@@ -304,7 +304,7 @@ where
         Ok(())
     }
 
-    #[instrument(level = "debug", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err)]
     fn remove(&self, key: &K) -> Result<(), TypedStoreError> {
         let key_buf = be_fix_int_ser(key)?;
 
@@ -312,7 +312,7 @@ where
         Ok(())
     }
 
-    #[instrument(level = "debug", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err)]
     fn clear(&self) -> Result<(), TypedStoreError> {
         let _ = self.rocksdb.drop_cf(&self.cf);
         self.rocksdb
@@ -346,7 +346,7 @@ where
     }
 
     /// Returns a vector of values corresponding to the keys provided.
-    #[instrument(level = "debug", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err)]
     fn multi_get<J>(
         &self,
         keys: impl IntoIterator<Item = J>,
@@ -375,7 +375,7 @@ where
     }
 
     /// Convenience method for batch insertion
-    #[instrument(level = "debug", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err)]
     fn multi_insert<J, U>(
         &self,
         key_val_pairs: impl IntoIterator<Item = (J, U)>,
@@ -388,7 +388,7 @@ where
     }
 
     /// Convenience method for batch removal
-    #[instrument(level = "debug", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err)]
     fn multi_remove<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<(), Self::Error>
     where
         J: Borrow<K>,


### PR DESCRIPTION
Logs in cloudwatch right now are 99% this:

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/103447440/175964382-857379e0-2d78-44ef-ac48-eb3af8add36d.png">

This does two things:
* downgrade unhelpful debug-level tracing around DB operations to trace.
* Don't write colored logs to stdout unless on a terminal.