### PR TITLE
fix broken workflow

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -15,5 +15,5 @@ jobs:
     - uses: actions/checkout@v3
     - name: Spell Check Docs
       uses: crate-ci/typos@master
-      with:
-        files: ./*/*.md
+      # with:
+      #   files: *.md ./*/*.md

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Spell Check Docs
       uses: crate-ci/typos@master
       with:
-        files: *.md ./*/*.md
+        files: ./*/*.md


### PR DESCRIPTION
I noticed that this workflow is broken.

I disabled the `with: files:` in an attempt to fix, however it now runs on the entire repo, which I think is likely not desirable.

Thoughts @huitseeker ?

Documentation i think is here: https://github.com/crate-ci/typos/blob/master/docs/github-action.md