### PR TITLE
[crypto] Create verifier of X.509 `SubjectPublicKeyInfo` against a collection of known PKs.

### DIFF
--- a/crates/rccheck/src/lib.rs
+++ b/crates/rccheck/src/lib.rs
@@ -73,10 +73,10 @@ pub trait Certifiable {
 /// let mut rng = rand::thread_rng();
 /// let keypairs: Vec<_> = (0..10).into_iter().map(|_| ed25519_dalek::Keypair::generate(&mut rng)).collect();
 /// let spkis = keypairs.iter().map(|kp| ed25519_certgen::Ed25519::public_key_to_spki(&kp.public)).collect::<Vec<_>>();
-/// let psket PskSet::from_der(&spkis.iter().map(|spki| &spki[..]).collect::<Vec<_>>()[..]).unwrap();
+/// let pskset = PskSet::from_der(&spkis.iter().map(|spki| &spki[..]).collect::<Vec<_>>()[..]).unwrap();
 /// ```
 ///
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PskSet {
     pub spki_set: BTreeSet<Psk>,
 }

--- a/crates/rccheck/src/lib.rs
+++ b/crates/rccheck/src/lib.rs
@@ -23,12 +23,17 @@ use serde::{
     de::{Error, Visitor},
     Deserialize, Deserializer, Serialize,
 };
+use std::collections::BTreeSet;
 use x509_parser::certificate::X509Certificate;
 use x509_parser::{traits::FromDer, x509::SubjectPublicKeyInfo};
 
 #[cfg(test)]
 #[path = "tests/psk_tests.rs"]
 mod psk_tests;
+
+#[cfg(test)]
+#[path = "tests/psk_set_tests.rs"]
+mod psk_set_tests;
 
 #[cfg(test)]
 #[path = "tests/test_utils.rs"]
@@ -55,6 +60,118 @@ pub trait Certifiable {
 
     /// This generates X.509 `SubjectPublicKeyInfo` (SPKI) bytes (in DER format) from the provided public key
     fn public_key_to_spki(public_key: &Self::PublicKey) -> Vec<u8>;
+}
+
+/// A collection of X.509 `SubjectPublicKeyInfo` (SPKI)
+///
+/// Implements the traits ClientCertVerifier and ServerCertVerifier, enabling the verification
+/// of X.509 certificates signed by a keypair in the set of Pre-Shared Keys (PSKs).
+///
+/// Example
+/// ```
+/// use rccheck::*;
+/// let mut rng = rand::thread_rng();
+/// let keypairs: Vec<_> = (0..10).into_iter().map(|_| ed25519_dalek::Keypair::generate(&mut rng)).collect();
+/// let spkis = keypairs.iter().map(|kp| ed25519_certgen::Ed25519::public_key_to_spki(&kp.public)).collect::<Vec<_>>();
+/// let psket PskSet::from_der(&spkis.iter().map(|spki| &spki[..]).collect::<Vec<_>>()[..]).unwrap();
+/// ```
+///
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PskSet {
+    pub spki_set: BTreeSet<Psk>,
+}
+
+impl PskSet {
+    /// This creates a new `PskSet` from a set of X.509 `SubjectPublicKeyInfo` (SPKI) bytes (in DER format)
+    pub fn from_der(bytes_array: &[&[u8]]) -> Result<PskSet, anyhow::Error> {
+        let set = bytes_array
+            .iter()
+            .map(|&bytes| {
+                let psk = Psk::from_der(bytes)?;
+                Ok(psk)
+            })
+            .collect::<Result<BTreeSet<Psk>, anyhow::Error>>()?;
+        Ok(PskSet { spki_set: set })
+    }
+}
+
+/// A `ClientCertVerifier` that will ensure that every client provides a valid, expected
+/// certificate, without any name checking.
+impl ClientCertVerifier for PskSet {
+    fn offer_client_auth(&self) -> bool {
+        true
+    }
+
+    fn client_auth_mandatory(&self) -> Option<bool> {
+        Some(true)
+    }
+
+    fn client_auth_root_subjects(&self) -> Option<rustls::DistinguishedNames> {
+        // We can't guarantee subjects before having seen the cert. This should not be None for compatiblity reasons
+        Some(rustls::DistinguishedNames::new())
+    }
+
+    // Verifies this is a valid certificate self-signed by a public key we expect(in PSK)
+    // 1. We check if the key exists in the set of expected keys.
+    // 2. Verify the key against expected key.
+    fn verify_client_cert(
+        &self,
+        end_entity: &rustls::Certificate,
+        intermediates: &[rustls::Certificate],
+        now: SystemTime,
+    ) -> Result<ClientCertVerified, rustls::Error> {
+        // 1. Check if the key exists in the set of expected keys.
+        let cert = X509Certificate::from_der(&end_entity.0[..])
+            .map_err(|_| rustls::Error::InvalidCertificateEncoding)?;
+        let pk_bytes = cert.1.public_key().raw.to_vec();
+        let spki = Psk::from_der(&pk_bytes).unwrap();
+
+        if !self.spki_set.contains(&spki) {
+            return Err(rustls::Error::InvalidCertificateData(
+                "invalid peer certificate: Provided public key is not in the set of accepted public keys".to_string()
+            ));
+        }
+
+        verify_client_cert_internal(end_entity, intermediates, now)
+    }
+}
+
+impl ServerCertVerifier for PskSet {
+    // Verifies this is a valid certificate self-signed by the public key we expect(in PSK)
+    // 1. we check the equality of the certificate's public key with the key we expect
+    // 2. we prepare arguments for webpki's certificate verification (following the rustls implementation)
+    //    placing the public key at the root of the certificate chain (as it should be for a self-signed certificate)
+    // 3. we call webpki's certificate verification
+    fn verify_server_cert(
+        &self,
+        end_entity: &rustls::Certificate,
+        intermediates: &[rustls::Certificate],
+        server_name: &rustls::ServerName,
+        scts: &mut dyn Iterator<Item = &[u8]>,
+        ocsp_response: &[u8],
+        now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        // 1. Check if the key exists in the set of expected keys.
+        let cert = X509Certificate::from_der(&end_entity.0[..])
+            .map_err(|_| rustls::Error::InvalidCertificateEncoding)?;
+        let pk_bytes = cert.1.public_key().raw.to_vec();
+        let spki = Psk::from_der(&pk_bytes).unwrap();
+
+        if !self.spki_set.contains(&spki) {
+            return Err(rustls::Error::InvalidCertificateData(
+                "invalid peer certificate: Provided public key is not in the set of accepted public keys".to_string()
+            ));
+        }
+
+        verify_server_cert_internal(
+            end_entity,
+            intermediates,
+            server_name,
+            scts,
+            ocsp_response,
+            now,
+        )
+    }
 }
 
 /// X.509 `SubjectPublicKeyInfo` (SPKI) as defined in [RFC 5280 Section 4.1.2.7].
@@ -163,6 +280,18 @@ impl<'de> Deserialize<'de> for Psk {
 /// end Ser/de
 ////////////////////////////////////////////////////////////////
 
+impl PartialOrd<Self> for Psk {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.borrow_key_bytes().cmp(other.borrow_key_bytes()))
+    }
+}
+
+impl Ord for Psk {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
 /// A `ClientCertVerifier` that will ensure that every client provides a valid, expected
 /// certificate, without any name checking.
 impl ClientCertVerifier for Psk {
@@ -202,20 +331,7 @@ impl ClientCertVerifier for Psk {
             )));
         }
 
-        // We now check we're receiving correctly signed data with the expected key
-        // Step 2: prepare arguments
-        let (cert, chain, trustroots) = prepare_for_self_signed(end_entity, intermediates)?;
-        let now = webpki::Time::try_from(now).map_err(|_| rustls::Error::FailedToGetCurrentTime)?;
-
-        // Step 3: call verification from webpki
-        cert.verify_is_valid_tls_client_cert(
-            SUPPORTED_SIG_ALGS,
-            &webpki::TlsClientTrustAnchors(&trustroots),
-            &chain,
-            now,
-        )
-        .map_err(pki_error)
-        .map(|_| ClientCertVerified::assertion())
+        verify_client_cert_internal(end_entity, intermediates, now)
     }
 }
 
@@ -246,46 +362,93 @@ impl ServerCertVerifier for Psk {
             )));
         }
 
-        // Then we check this is actually a valid self-signed certificate with matching name
-        // Step 2: prepare arguments
-        let (cert, chain, trustroots) = prepare_for_self_signed(end_entity, intermediates)?;
-        let webpki_now =
-            webpki::Time::try_from(now).map_err(|_| rustls::Error::FailedToGetCurrentTime)?;
-
-        let dns_nameref = match server_name {
-            rustls::ServerName::DnsName(dns_name) => {
-                webpki::DnsNameRef::try_from_ascii_str(dns_name.as_ref())
-                    .map_err(|_| rustls::Error::UnsupportedNameType)?
-            }
-            _ => return Err(rustls::Error::UnsupportedNameType),
-        };
-
-        // Step 3: call verification from webpki
-        let cert = cert
-            .verify_is_valid_tls_server_cert(
-                SUPPORTED_SIG_ALGS,
-                &webpki::TlsServerTrustAnchors(&trustroots),
-                &chain,
-                webpki_now,
-            )
-            .map_err(pki_error)
-            .map(|_| cert)?;
-
-        // log additional certificate transaparency info (which is pointless in our self-signed context) and return
-        let mut peekable = scts.peekable();
-        if peekable.peek().is_none() {
-            tracing::trace!("Met unvalidated certificate transparency data");
-        }
-
-        if !ocsp_response.is_empty() {
-            tracing::trace!("Unvalidated OCSP response: {:?}", ocsp_response.to_vec());
-        }
-
-        cert.verify_is_valid_for_dns_name(dns_nameref)
-            .map_err(pki_error)
-            .map(|_| ServerCertVerified::assertion())
+        verify_server_cert_internal(
+            end_entity,
+            intermediates,
+            server_name,
+            scts,
+            ocsp_response,
+            now,
+        )
     }
 }
+
+////////////////////////////////////////////////////////////////
+/// Certificate Verification Helpers
+////////////////////////////////////////////////////////////////
+
+fn verify_client_cert_internal(
+    end_entity: &rustls::Certificate,
+    intermediates: &[rustls::Certificate],
+    now: SystemTime,
+) -> Result<ClientCertVerified, rustls::Error> {
+    // We now check we're receiving correctly signed data with the expected key
+    // Step 2: prepare arguments
+    let (cert, chain, trustroots) = prepare_for_self_signed(end_entity, intermediates)?;
+    let now = webpki::Time::try_from(now).map_err(|_| rustls::Error::FailedToGetCurrentTime)?;
+
+    // Step 3: call verification from webpki
+    cert.verify_is_valid_tls_client_cert(
+        SUPPORTED_SIG_ALGS,
+        &webpki::TlsClientTrustAnchors(&trustroots),
+        &chain,
+        now,
+    )
+    .map_err(pki_error)
+    .map(|_| ClientCertVerified::assertion())
+}
+
+fn verify_server_cert_internal(
+    end_entity: &rustls::Certificate,
+    intermediates: &[rustls::Certificate],
+    server_name: &rustls::ServerName,
+    scts: &mut dyn Iterator<Item = &[u8]>,
+    ocsp_response: &[u8],
+    now: std::time::SystemTime,
+) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+    // Then we check this is actually a valid self-signed certificate with matching name
+    // Step 2: prepare arguments
+    let (cert, chain, trustroots) = prepare_for_self_signed(end_entity, intermediates)?;
+    let webpki_now =
+        webpki::Time::try_from(now).map_err(|_| rustls::Error::FailedToGetCurrentTime)?;
+
+    let dns_nameref = match server_name {
+        rustls::ServerName::DnsName(dns_name) => {
+            webpki::DnsNameRef::try_from_ascii_str(dns_name.as_ref())
+                .map_err(|_| rustls::Error::UnsupportedNameType)?
+        }
+        _ => return Err(rustls::Error::UnsupportedNameType),
+    };
+
+    // Step 3: call verification from webpki
+    let cert = cert
+        .verify_is_valid_tls_server_cert(
+            SUPPORTED_SIG_ALGS,
+            &webpki::TlsServerTrustAnchors(&trustroots),
+            &chain,
+            webpki_now,
+        )
+        .map_err(pki_error)
+        .map(|_| cert)?;
+
+    // log additional certificate transaparency info (which is pointless in our self-signed context) and return
+    let mut peekable = scts.peekable();
+    if peekable.peek().is_none() {
+        tracing::trace!("Met unvalidated certificate transparency data");
+    }
+
+    if !ocsp_response.is_empty() {
+        tracing::trace!("Unvalidated OCSP response: {:?}", ocsp_response.to_vec());
+    }
+
+    cert.verify_is_valid_for_dns_name(dns_nameref)
+        .map_err(pki_error)
+        .map(|_| ServerCertVerified::assertion())
+}
+
+////////////////////////////////////////////////////////////////
+/// End Certificate Verification Helpers
+////////////////////////////////////////////////////////////////
 
 type CertChainAndRoots<'a> = (
     webpki::EndEntityCert<'a>,

--- a/crates/rccheck/src/tests/psk_set_tests.rs
+++ b/crates/rccheck/src/tests/psk_set_tests.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ed25519_certgen::Ed25519, *};
+use rcgen::generate_simple_self_signed;
+use rustls::{client::ServerCertVerifier, server::ClientCertVerifier};
+use x509_parser::traits::FromDer;
+
+fn cert_bytes_to_spki_bytes(cert_bytes: &[u8]) -> Vec<u8> {
+    let cert_parsed = X509Certificate::from_der(cert_bytes)
+        .map_err(|_| rustls::Error::InvalidCertificateEncoding)
+        .unwrap();
+    let spki = cert_parsed.1.public_key().clone();
+    spki.raw.to_vec()
+}
+
+#[test]
+fn serde_round_trip() {
+    let subject_alt_names = vec!["localhost".to_string()];
+
+    let cert = generate_simple_self_signed(subject_alt_names).unwrap();
+    let cert_bytes: Vec<u8> = cert.serialize_der().unwrap();
+
+    let spki = cert_bytes_to_spki_bytes(&cert_bytes);
+    let psk = Psk::from_der(&spki).unwrap();
+    let psk_bytes = bincode::serialize(&psk).unwrap();
+    let psk_roundtripped = bincode::deserialize::<Psk>(&psk_bytes).unwrap();
+    assert_eq!(psk, psk_roundtripped);
+}
+
+#[test]
+fn rc_gen_self_signed_dalek() {
+    let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::from_seed([0; 32]);
+    let kp = ed25519_dalek::Keypair::generate(&mut rng);
+    let kp2 = ed25519_dalek::Keypair::generate(&mut rng);
+
+    let subject_alt_names = vec!["localhost".to_string()];
+
+    let public_key = kp.public;
+    let public_key_2 = kp2.public;
+
+    let spki = Ed25519::public_key_to_spki(&public_key);
+    let spki2 = Ed25519::public_key_to_spki(&public_key_2);
+
+    let psk_set = PskSet::from_der(&[&spki[..], &spki2[..]]).unwrap();
+    let now = SystemTime::now();
+
+    let cert = Ed25519::keypair_to_certificate(subject_alt_names, kp).unwrap();
+
+    // this passes client verification
+    psk_set.verify_client_cert(&cert, &[], now).unwrap();
+
+    // this passes server verification
+    let mut empty = std::iter::empty();
+    psk_set
+        .verify_server_cert(
+            &cert,
+            &[],
+            &rustls::ServerName::try_from("localhost").unwrap(),
+            &mut empty,
+            &[],
+            now,
+        )
+        .unwrap();
+}
+
+#[test]
+fn rc_gen_not_self_signed_dalek() {
+    let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::from_seed([0; 32]);
+    let kp = ed25519_dalek::Keypair::generate(&mut rng);
+    let invalid_kp = ed25519_dalek::Keypair::generate(&mut rng);
+
+    let subject_alt_names = vec!["localhost".to_string()];
+
+    let public_key = kp.public;
+
+    let spki = Ed25519::public_key_to_spki(&public_key);
+
+    let psk_set = PskSet::from_der(&[&spki[..]]).unwrap();
+    let now = SystemTime::now();
+
+    let invalid_cert = Ed25519::keypair_to_certificate(subject_alt_names, invalid_kp).unwrap();
+
+    // this does not pass client verification
+    assert!(psk_set
+        .verify_client_cert(&invalid_cert, &[], now)
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("invalid peer certificate"));
+
+    // this passes server verification
+    let mut empty = std::iter::empty();
+    assert!(psk_set
+        .verify_server_cert(
+            &invalid_cert,
+            &[],
+            &rustls::ServerName::try_from("localhost").unwrap(),
+            &mut empty,
+            &[],
+            now,
+        )
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("invalid peer certificate"));
+}

--- a/crates/rccheck/src/tests/psk_tests.rs
+++ b/crates/rccheck/src/tests/psk_tests.rs
@@ -1,18 +1,9 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::*;
+use crate::{test_utils::cert_bytes_to_spki_bytes, *};
 use rcgen::generate_simple_self_signed;
 use rustls::{client::ServerCertVerifier, server::ClientCertVerifier};
-use x509_parser::traits::FromDer;
-
-fn cert_bytes_to_spki_bytes(cert_bytes: &[u8]) -> Vec<u8> {
-    let cert_parsed = X509Certificate::from_der(cert_bytes)
-        .map_err(|_| rustls::Error::InvalidCertificateEncoding)
-        .unwrap();
-    let spki = cert_parsed.1.public_key().clone();
-    spki.raw.to_vec()
-}
 
 #[test]
 fn serde_round_trip() {

--- a/crates/rccheck/src/tests/test_utils.rs
+++ b/crates/rccheck/src/tests/test_utils.rs
@@ -3,6 +3,12 @@
 
 use proptest::prelude::*;
 use proptest::strategy::Strategy;
+use x509_parser::prelude::X509Certificate;
+use x509_parser::traits::FromDer;
+
+///
+/// Proptest Helpers
+///
 
 pub fn dalek_keypair_strategy() -> impl Strategy<Value = ed25519_dalek::Keypair> {
     any::<[u8; 32]>()
@@ -15,4 +21,16 @@ pub fn dalek_keypair_strategy() -> impl Strategy<Value = ed25519_dalek::Keypair>
 
 pub fn dalek_pubkey_strategy() -> impl Strategy<Value = ed25519_dalek::PublicKey> {
     dalek_keypair_strategy().prop_map(|v| v.public)
+}
+
+///
+/// Misc Helpers
+///
+
+pub fn cert_bytes_to_spki_bytes(cert_bytes: &[u8]) -> Vec<u8> {
+    let cert_parsed = X509Certificate::from_der(cert_bytes)
+        .map_err(|_| rustls::Error::InvalidCertificateEncoding)
+        .unwrap();
+    let spki = cert_parsed.1.public_key().clone();
+    spki.raw.to_vec()
 }


### PR DESCRIPTION
Adds a struct that implements ClientCertVerifier/ServerCertVerifier, which allows the verification of X.509 certificates against a set of pre-shared public keys, as discussed in: #98.

This PR will build up towards implementing mutual TLS (mTLS) [https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/] for connections within Sui and Narwhal.