### PR TITLE
Add a ultility function to convert `MultiAddr` to `SocketAddr`

### DIFF
--- a/crates/mysten-network/src/lib.rs
+++ b/crates/mysten-network/src/lib.rs
@@ -4,5 +4,5 @@ pub mod client;
 pub mod codec;
 pub mod config;
 pub mod metrics;
-mod multiaddr;
+pub mod multiaddr;
 pub mod server;

--- a/crates/mysten-network/src/multiaddr.rs
+++ b/crates/mysten-network/src/multiaddr.rs
@@ -8,6 +8,21 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
+// Converts a /ip{4,6}/-/tcp/- address to SocketAddr.
+pub fn to_socket_addr(addr: &Multiaddr) -> Result<SocketAddr> {
+    let mut iter = addr.iter();
+    let ip = match iter
+        .next()
+        .ok_or_else(|| anyhow!("failed to convert to SocketAddr: Multiaddr does not contain IP"))?
+    {
+        Protocol::Ip4(ip4_addr) => IpAddr::V4(ip4_addr),
+        Protocol::Ip6(ip6_addr) => IpAddr::V6(ip6_addr),
+        unsupported => return Err(anyhow!("unsupported protocol {unsupported}")),
+    };
+    let tcp_port = parse_tcp(&mut iter)?;
+    Ok(SocketAddr::new(ip, tcp_port))
+}
+
 pub(crate) fn parse_tcp<'a, T: Iterator<Item = Protocol<'a>>>(protocols: &mut T) -> Result<u16> {
     if let Protocol::Tcp(port) = protocols
         .next()
@@ -111,4 +126,23 @@ pub(crate) fn parse_unix(address: &Multiaddr) -> Result<(Cow<'_, str>, &'static 
     parse_end(&mut iter)?;
 
     Ok((path, http_or_https))
+}
+
+#[cfg(test)]
+mod test {
+    use super::to_socket_addr;
+    use multiaddr::multiaddr;
+
+    #[test]
+    fn test_to_socket_addr() {
+        let multi_addr_ipv4 = multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10500u16));
+        let socket_addr_ipv4 =
+            to_socket_addr(&multi_addr_ipv4).expect("Couldn't convert to socket addr");
+        assert_eq!(socket_addr_ipv4.to_string(), "127.0.0.1:10500");
+
+        let multi_addr_ipv6 = multiaddr!(Ip6([172, 0, 0, 1, 1, 1, 1, 1]), Tcp(10500u16));
+        let socket_addr_ipv6 =
+            to_socket_addr(&multi_addr_ipv6).expect("Couldn't convert to socket addr");
+        assert_eq!(socket_addr_ipv6.to_string(), "[ac::1:1:1:1:1]:10500");
+    }
 }

--- a/crates/mysten-network/src/multiaddr.rs
+++ b/crates/mysten-network/src/multiaddr.rs
@@ -10,6 +10,7 @@ use std::{
 
 // Converts a /ip{4,6}/-/tcp/-[/-] Multiaddr to SocketAddr.
 // Useful when an external library only accepts SocketAddr, e.g. to start a local server.
+// See `client::endpoint_from_multiaddr()` for converting to Endpoint for clients.
 pub fn to_socket_addr(addr: &Multiaddr) -> Result<SocketAddr> {
     let mut iter = addr.iter();
     let ip = match iter

--- a/crates/mysten-network/src/multiaddr.rs
+++ b/crates/mysten-network/src/multiaddr.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 // Converts a /ip{4,6}/-/tcp/-[/-] Multiaddr to SocketAddr.
+// Useful when an external library only accepts SocketAddr, e.g. to start a local server.
 pub fn to_socket_addr(addr: &Multiaddr) -> Result<SocketAddr> {
     let mut iter = addr.iter();
     let ip = match iter
@@ -134,7 +135,7 @@ mod test {
     use multiaddr::multiaddr;
 
     #[test]
-    fn test_to_socket_addr() {
+    fn test_to_socket_addr_basic() {
         let multi_addr_ipv4 = multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10500u16));
         let socket_addr_ipv4 =
             to_socket_addr(&multi_addr_ipv4).expect("Couldn't convert to socket addr");
@@ -144,5 +145,11 @@ mod test {
         let socket_addr_ipv6 =
             to_socket_addr(&multi_addr_ipv6).expect("Couldn't convert to socket addr");
         assert_eq!(socket_addr_ipv6.to_string(), "[ac::1:1:1:1:1]:10500");
+    }
+
+    #[test]
+    fn test_to_socket_addr_unsupported_protocol() {
+        let multi_addr_dns = multiaddr!(Dnsaddr("mysten.sui"), Tcp(10500u16));
+        to_socket_addr(&multi_addr_dns).expect_err("DNS is unsupported");
     }
 }

--- a/crates/mysten-network/src/multiaddr.rs
+++ b/crates/mysten-network/src/multiaddr.rs
@@ -8,7 +8,7 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-// Converts a /ip{4,6}/-/tcp/- address to SocketAddr.
+// Converts a /ip{4,6}/-/tcp/-[/-] Multiaddr to SocketAddr.
 pub fn to_socket_addr(addr: &Multiaddr) -> Result<SocketAddr> {
     let mut iter = addr.iter();
     let ip = match iter


### PR DESCRIPTION
For https://github.com/MystenLabs/narwhal/issues/575, we need to convert `MultiAddr` to `SocketAddr`, which is accept by the `axum::Server::bind()`. It seems the best place to add this ultility is in `mysten-network`.