### PR TITLE
[rccheck] Externally signed x.509 TLS Certificates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,8 +42,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          persist-credentials: false
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v1
         with:
@@ -72,8 +70,8 @@ jobs:
           git push origin "${{ matrix.package}}-v$CURRENT_VERSION"
       - uses: actions-rs/toolchain@v1
         if: steps.check.outputs.is_new_version == 'yes'
-      - name: Publish
+      - name: Publish packages
         if: steps.check.outputs.is_new_version == 'yes'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish
+        run: cargo publish -p ${{ matrix.package }}

--- a/crates/rccheck/Cargo.toml
+++ b/crates/rccheck/Cargo.toml
@@ -14,7 +14,7 @@ ed25519-dalek = "1.0.1"
 eyre = "0.6.8"
 ouroboros = "0.15.1"
 pkcs8 = { version = "0.9.0", features = ["std"] }
-rcgen = "0.9.3"
+rcgen = { version = "0.9.3", features = ["x509-parser"] }
 rustls = { version = "0.20.6", default-features = false, features = ["logging", "dangerous_configuration"] }
 serde = { version = "1.0.140", features = ["derive"] }
 tracing = "0.1.36"
@@ -25,3 +25,6 @@ x509-parser = "0.13.0"
 bincode = "1.3.3"
 proptest = "1.0.0"
 rand = "0.7.3"
+
+[env]
+COMMON_DISTINGUISHED_NAME = "NARWHAL"

--- a/crates/rccheck/proptest-regressions/tests/ed25519_certgen_tests.txt
+++ b/crates/rccheck/proptest-regressions/tests/ed25519_certgen_tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 2314fa35d5986111fdc8a2e76ea8c71740afee8009f5a5562334ec93f9b9f3c3 # shrinks to kp = Keypair { secret: SecretKey: [242, 33, 74, 135, 132, 113, 26, 59, 115, 111, 186, 109, 99, 50, 165, 102, 95, 247, 82, 254, 166, 81, 194, 89, 227, 90, 236, 179, 199, 229, 9, 176], public: PublicKey(CompressedEdwardsY: [36, 252, 248, 160, 223, 187, 68, 119, 111, 224, 216, 76, 235, 141, 167, 246, 199, 188, 186, 164, 160, 100, 176, 30, 145, 135, 53, 99, 212, 141, 235, 105]), EdwardsPoint{ 	X: FieldElement51([636188592870209, 2122666908395076, 1759756592963115, 407366879547462, 1514920451640683]), 	Y: FieldElement51([1934028786357739, 917481144122446, 1075599933454187, 431199849450843, 1369755919471043]), 	Z: FieldElement51([506105058121111, 2016703970022612, 206462402701108, 1275383251367447, 1679329397810154]), 	T: FieldElement51([380064152557241, 1407294455312354, 1352227124520218, 1140276849245621, 1008811480537287]) }) }

--- a/crates/rccheck/src/tests/ed25519_external_trust_anchor.rs
+++ b/crates/rccheck/src/tests/ed25519_external_trust_anchor.rs
@@ -1,0 +1,91 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::SystemTime;
+
+use super::*;
+use crate::{ed25519_certgen::Ed25519, test_utils::dalek_keypair_strategy, PskSet};
+
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn rc_gen_ca_client_split(
+        client_kp in dalek_keypair_strategy(),
+        ca_kp in dalek_keypair_strategy(),
+    ) {
+        let subject_alt_names = vec!["localhost".to_string()];
+
+        let ca_public_key = ca_kp.public;
+
+        // 1. Generate CSR on client
+        let cert_request =
+            Ed25519::keypair_to_der_certificate_request(subject_alt_names, client_kp).unwrap();
+
+        // (2) Client sends CSR to CA
+
+        // CA signs CSR and produces Certificate
+        let cert = Ed25519::sign_certificate_request(&cert_request[..], ca_kp).unwrap();
+
+        let ca_spki = Ed25519::public_key_to_spki(&ca_public_key);
+        let now = SystemTime::now();
+
+        let psk_set = PskSet::from_der(&[&ca_spki[..]]).unwrap();
+        let mut empty = std::iter::empty();
+
+        assert!(psk_set
+            .verify_client_cert(&ca_spki, &cert, &[], now)
+            .is_ok());
+        assert!(psk_set
+            .verify_server_cert(
+                &ca_spki,
+                &cert,
+                &[],
+                &rustls::ServerName::try_from("localhost").unwrap(),
+                &mut empty,
+                &[],
+                now,
+            )
+            .is_ok());
+    }
+
+    #[test]
+    fn rc_gen_ca_client_split_err(
+        client_kp in dalek_keypair_strategy(),
+        ca_kp in dalek_keypair_strategy()
+    ) {
+        let client_kp_copy = ed25519_dalek::Keypair::from_bytes(&client_kp.to_bytes()).unwrap();
+
+        let subject_alt_names = vec!["localhost".to_string()];
+
+        let ca_public_key = ca_kp.public;
+
+        // 1. Generate CSR on client
+        let cert_request =
+            Ed25519::keypair_to_der_certificate_request(subject_alt_names, client_kp).unwrap();
+
+        // Client signs CSR and produces Certificate
+        let cert = Ed25519::sign_certificate_request(&cert_request[..], client_kp_copy).unwrap();
+
+        let ca_spki = Ed25519::public_key_to_spki(&ca_public_key);
+        let now = SystemTime::now();
+
+        let psk_set = PskSet::from_der(&[&ca_spki[..]]).unwrap();
+        let mut empty = std::iter::empty();
+
+        assert!(psk_set
+            .verify_client_cert(&ca_spki, &cert, &[], now)
+            .is_err());
+        assert!(psk_set
+            .verify_server_cert(
+                &ca_spki,
+                &cert,
+                &[],
+                &rustls::ServerName::try_from("localhost").unwrap(),
+                &mut empty,
+                &[],
+                now,
+            )
+            .is_err());
+    }
+}

--- a/crates/rccheck/src/tests/psk_tests.rs
+++ b/crates/rccheck/src/tests/psk_tests.rs
@@ -27,6 +27,7 @@ fn rc_gen_self_client() {
     let cert_bytes: Vec<u8> = cert.serialize_der().unwrap();
     let spki = cert_bytes_to_spki_bytes(&cert_bytes);
     let psk = Psk::from_der(&spki).unwrap();
+
     let now = SystemTime::now();
     let rstls_cert = rustls::Certificate(cert_bytes);
 


### PR DESCRIPTION
#### Summary
We need to allow certificates to be signed by other keypairs to allow for the scale-out architecture that we are developing for Narwhal and Sui.

This PR introduces support for externally signed certificates. This is required for the primary/worker split in Narwhal  - we must allow workers to request x.509 certificates from their primaries, which will be used for authentication by other primaries.