### PR TITLE
Set default total memtable size to 512MB per Rocksdb

### DIFF
--- a/crates/typed-store-macros/src/lib.rs
+++ b/crates/typed-store-macros/src/lib.rs
@@ -151,8 +151,6 @@ pub fn derive_dbmap_utils(input: TokenStream) -> TokenStream {
                 db_options: Option<rocksdb::Options>,
             ) -> Self {
                 let path = &path;
-                let db_options = db_options.unwrap_or_default().clone();
-
                 let db = {
                     let opt_cfs: &[(&str, &rocksdb::Options)] = &[
                         #(
@@ -161,9 +159,9 @@ pub fn derive_dbmap_utils(input: TokenStream) -> TokenStream {
                     ];
 
                     if let Some(p) = with_secondary_path {
-                        typed_store::rocks::open_cf_opts_secondary(path, Some(&p), Some(db_options), opt_cfs)
+                        typed_store::rocks::open_cf_opts_secondary(path, Some(&p), db_options, opt_cfs)
                     } else {
-                        typed_store::rocks::open_cf_opts(path, Some(db_options), opt_cfs)
+                        typed_store::rocks::open_cf_opts(path, db_options, opt_cfs)
                     }
                 }.expect("Cannot open DB.");
 

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -16,6 +16,9 @@ use tracing::instrument;
 use self::{iter::Iter, keys::Keys, values::Values};
 pub use errors::TypedStoreError;
 
+// The default bytes limit on total memtable size per RocksDB.
+const DB_WRITE_BUFFER_SIZE: usize = 512 * 1024 * 1024;
+
 #[cfg(test)]
 mod tests;
 
@@ -430,8 +433,8 @@ where
 /// Creates a default Rocksdb option.
 pub fn default_rocksdb_options() -> rocksdb::Options {
     let mut opt = rocksdb::Options::default();
-    // Limit the total memtable memory usage per db.
-    opt.set_db_write_buffer_size(512 * 1024 * 1024);
+    // Limit the total memtable usage per db.
+    opt.set_db_write_buffer_size(DB_WRITE_BUFFER_SIZE);
     opt
 }
 

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -5,6 +5,8 @@ use rocksdb::Options;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{borrow::Borrow, collections::BTreeMap, error::Error, path::PathBuf};
 
+use crate::rocks::default_rocksdb_options;
+
 pub trait Map<'a, K, V>
 where
     K: Serialize + DeserializeOwned + ?Sized,
@@ -142,7 +144,7 @@ pub trait DBMapTableUtil {
         cache_capacity: usize,
         point_lookup: bool,
     ) -> rocksdb::Options {
-        let mut options = db_options.unwrap_or_default();
+        let mut options = db_options.unwrap_or_else(default_rocksdb_options);
 
         // One common issue when running tests on Mac is that the default ulimit is too low,
         // leading to I/O errors such as "Too many open files". Raising fdlimit to bypass it.


### PR DESCRIPTION
The goal is to limit total memtable bytes usage per Rocksdb. Assuming most of memtable memory usages is in 1 or a few dbs, this should reduce per-process memory usage as well. 

I have not verified that this change reduces the maximum total size of memtables in `stress` benchmark though. In fact I'm not sure how to build Sui with this change without merging it.

Related to https://github.com/MystenLabs/narwhal/issues/671