### PR TITLE
fix: remove the anyhow backtrace feature

### DIFF
--- a/crates/typed-store-macros-tests/Cargo.toml
+++ b/crates/typed-store-macros-tests/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 syn = { version = "1.0.64", features = ["derive"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.24"
-anyhow = { version = "1.0.58", features = ["backtrace"] }
+anyhow = { version = "1.0.58" }
 typed-store = {path = "../typed-store"}
 tempfile = "3.3.0"
 tokio = { version = "1.20.0", features = ["sync", "macros", "rt"] }

--- a/crates/typed-store-macros/Cargo.toml
+++ b/crates/typed-store-macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 syn = { version = "1.0.64", features = ["derive"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.24"
-anyhow = { version = "1.0.58", features = ["backtrace"] }
+anyhow = { version = "1.0.58"}
 typed-store = {path = "../typed-store"}
 tokio = { version = "1.20.0", features = ["sync", "macros", "rt"] }
 tempfile = "3.3.0"

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.20.1", features = ["sync", "macros", "rt"] }
 thiserror = "1.0.31"
 collectable = "0.0.2"
 fdlimit = "0.2.1"
-anyhow = { version = "1.0.58", features = ["backtrace"] }
+anyhow = { version = "1.0.58" }
 pre = "0.2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
the workspace-hack from cargo-hakari unifies the versions we use to a major version number (1) =>
we hit https://github.com/dtolnay/anyhow/issues/250

This removes the `backtrace` feature.