### PR TITLE
refactor: replace anyhow by eyre everywhere

### DIFF
--- a/crates/component/Cargo.toml
+++ b/crates/component/Cargo.toml
@@ -7,10 +7,9 @@ description = "library for resilient component supervision"
 repository = "https://github.com/mystenlabs/mysten-infra"
 edition = "2021"
 publish = false
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.20.1", features = ["sync", "macros", "rt", "rt-multi-thread"] }
 async-trait = "0.1.56"
-anyhow = "1.0.58"
+eyre = "0.6.8"
+tokio = { version = "1.20.1", features = ["sync", "macros", "rt", "rt-multi-thread"] }

--- a/crates/mysten-network/Cargo.toml
+++ b/crates/mysten-network/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1.0.58"
 bincode = "1.3.3"
 bytes = "1.2.1"
+eyre = "0.6.8"
+futures = "0.3.21"
 http = "0.2.8"
 multiaddr = "0.14.0"
-futures = "0.3.21"
 serde = { version = "1.0.140", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["sync", "rt", "macros"] }
 tokio-stream = { version = "0.1.9", features = ["net"] }

--- a/crates/mysten-network/src/client.rs
+++ b/crates/mysten-network/src/client.rs
@@ -5,7 +5,7 @@ use crate::{
     config::Config,
     multiaddr::{parse_dns, parse_ip4, parse_ip6},
 };
-use anyhow::{anyhow, Context, Result};
+use eyre::{eyre, Context, Result};
 use multiaddr::{Multiaddr, Protocol};
 use tonic::transport::{Channel, Endpoint, Uri};
 
@@ -37,7 +37,7 @@ pub(crate) fn connect_lazy_with_config(address: &Multiaddr, config: &Config) -> 
 fn endpoint_from_multiaddr(addr: &Multiaddr) -> Result<MyEndpoint> {
     let mut iter = addr.iter();
 
-    let channel = match iter.next().ok_or_else(|| anyhow!("address is empty"))? {
+    let channel = match iter.next().ok_or_else(|| eyre!("address is empty"))? {
         Protocol::Dns(_) => {
             let (dns_name, tcp_port, http_or_https) = parse_dns(addr)?;
             let uri = format!("{http_or_https}://{dns_name}:{tcp_port}");
@@ -60,7 +60,7 @@ fn endpoint_from_multiaddr(addr: &Multiaddr) -> Result<MyEndpoint> {
             let uri = format!("{http_or_https}://localhost");
             MyEndpoint::try_from_uri(uri)?.with_uds_connector(path.as_ref().into())
         }
-        unsupported => return Err(anyhow!("unsupported protocol {unsupported}")),
+        unsupported => return Err(eyre!("unsupported protocol {unsupported}")),
     };
 
     Ok(channel)

--- a/crates/mysten-network/src/config.rs
+++ b/crates/mysten-network/src/config.rs
@@ -5,7 +5,7 @@ use crate::{
     client::{connect_lazy_with_config, connect_with_config},
     server::ServerBuilder,
 };
-use anyhow::Result;
+use eyre::Result;
 use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;

--- a/crates/mysten-network/src/server.rs
+++ b/crates/mysten-network/src/server.rs
@@ -8,7 +8,7 @@ use crate::{
     config::Config,
     multiaddr::{parse_dns, parse_ip4, parse_ip6},
 };
-use anyhow::{anyhow, Result};
+use eyre::{eyre, Result};
 use futures::FutureExt;
 use multiaddr::{Multiaddr, Protocol};
 use std::{convert::Infallible, net::SocketAddr};
@@ -156,7 +156,7 @@ impl<M: MetricsCallbackProvider> ServerBuilder<M> {
         let (tx_cancellation, rx_cancellation) = tokio::sync::oneshot::channel();
         let rx_cancellation = rx_cancellation.map(|_| ());
         let (local_addr, server): (Multiaddr, BoxFuture<(), tonic::transport::Error>) =
-            match iter.next().ok_or_else(|| anyhow!("malformed addr"))? {
+            match iter.next().ok_or_else(|| eyre!("malformed addr"))? {
                 Protocol::Dns(_) => {
                     let (dns_name, tcp_port, _http_or_https) = parse_dns(addr)?;
                     let (local_addr, incoming) =
@@ -201,7 +201,7 @@ impl<M: MetricsCallbackProvider> ServerBuilder<M> {
                     );
                     (local_addr, server)
                 }
-                unsupported => return Err(anyhow!("unsupported protocol {unsupported}")),
+                unsupported => return Err(eyre!("unsupported protocol {unsupported}")),
             };
 
         Ok(Server {

--- a/crates/name-variant/Cargo.toml
+++ b/crates/name-variant/Cargo.toml
@@ -12,6 +12,6 @@ publish = false
 proc-macro = true
 
 [dependencies]
-syn = "1.0.98"
-quote = "1.0.20"
 proc-macro2 = "1.0.42"
+quote = "1.0.20"
+syn = "1.0.98"

--- a/crates/rccheck/Cargo.toml
+++ b/crates/rccheck/Cargo.toml
@@ -9,17 +9,17 @@ edition = "2021"
 publish = false
 
 [dependencies]
+ed25519 = { version = "1.5.2", features = ["pkcs8", "alloc", "zeroize"] }
+ed25519-dalek = "1.0.1"
+eyre = "0.6.8"
+ouroboros = "0.15.1"
+pkcs8 = { version = "0.9.0", features = ["std"] }
+rcgen = "0.9.3"
 rustls = { version = "0.20.6", default-features = false, features = ["logging", "dangerous_configuration"] }
 serde = { version = "1.0.140", features = ["derive"] }
 tracing = "0.1.36"
 webpki = { version = "0.22.0", features = ["alloc", "std"] }
 x509-parser = "0.13.0"
-rcgen = "0.9.3"
-anyhow = "1.0.58"
-ed25519-dalek = "1.0.1"
-ed25519 = { version = "1.5.2", features = ["pkcs8", "alloc", "zeroize"] }
-pkcs8 = { version = "0.9.0", features = ["std"] }
-ouroboros = "0.15.1"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/crates/rccheck/src/ed25519_certgen.rs
+++ b/crates/rccheck/src/ed25519_certgen.rs
@@ -37,7 +37,7 @@ fn keypair_bytes_to_pkcs8_n_algo(
 fn gen_certificate(
     subject_names: impl Into<Vec<String>>,
     key_pair: (&[u8], &'static SignatureAlgorithm),
-) -> Result<rustls::Certificate, anyhow::Error> {
+) -> Result<rustls::Certificate, eyre::Report> {
     let kp = KeyPair::from_der_and_sign_algo(key_pair.0, key_pair.1)?;
 
     let mut cert_params = CertificateParams::new(subject_names);
@@ -79,10 +79,10 @@ impl Certifiable for Ed25519 {
     fn keypair_to_certificate(
         subject_names: impl Into<Vec<String>>,
         kp: Self::KeyPair,
-    ) -> Result<rustls::Certificate, anyhow::Error> {
+    ) -> Result<rustls::Certificate, eyre::Report> {
         let keypair_bytes = dalek_to_keypair_bytes(kp);
         let (pkcs_bytes, alg) =
-            keypair_bytes_to_pkcs8_n_algo(keypair_bytes).map_err(anyhow::Error::new)?;
+            keypair_bytes_to_pkcs8_n_algo(keypair_bytes).map_err(eyre::Report::new)?;
 
         let certificate = gen_certificate(subject_names, (pkcs_bytes.as_bytes(), alg))?;
         Ok(certificate)

--- a/crates/rccheck/src/lib.rs
+++ b/crates/rccheck/src/lib.rs
@@ -56,7 +56,7 @@ pub trait Certifiable {
     fn keypair_to_certificate(
         subject_names: impl Into<Vec<String>>,
         kp: Self::KeyPair,
-    ) -> Result<rustls::Certificate, anyhow::Error>;
+    ) -> Result<rustls::Certificate, eyre::Report>;
 
     /// This generates X.509 `SubjectPublicKeyInfo` (SPKI) bytes (in DER format) from the provided public key
     fn public_key_to_spki(public_key: &Self::PublicKey) -> Vec<u8>;
@@ -83,14 +83,14 @@ pub struct PskSet {
 
 impl PskSet {
     /// This creates a new `PskSet` from a set of X.509 `SubjectPublicKeyInfo` (SPKI) bytes (in DER format)
-    pub fn from_der(bytes_array: &[&[u8]]) -> Result<PskSet, anyhow::Error> {
+    pub fn from_der(bytes_array: &[&[u8]]) -> Result<PskSet, eyre::Report> {
         let set = bytes_array
             .iter()
             .map(|&bytes| {
                 let psk = Psk::from_der(bytes)?;
                 Ok(psk)
             })
-            .collect::<Result<BTreeSet<Psk>, anyhow::Error>>()?;
+            .collect::<Result<BTreeSet<Psk>, eyre::Report>>()?;
         Ok(PskSet { spki_set: set })
     }
 }
@@ -210,7 +210,7 @@ pub struct Psk {
 impl Eq for Psk {}
 
 impl Psk {
-    pub fn from_der(bytes: &[u8]) -> Result<Psk, anyhow::Error> {
+    pub fn from_der(bytes: &[u8]) -> Result<Psk, eyre::Report> {
         PskTryBuilder {
             key_bytes: bytes.to_vec(),
             spki_builder: |key_bytes: &Vec<u8>| {

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -9,18 +9,18 @@ edition = "2021"
 publish = false
 
 [dependencies]
+console-subscriber = { version = "0.1.6", optional = true }
+crossterm = "0.25.0"
+once_cell = "1.13.0"
+opentelemetry = { version = "0.17.0", features = ["rt-tokio"], optional = true }
+opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio"], optional = true }
 tokio = { version = "1.20.1", features = ["sync", "macros", "rt", "rt-multi-thread"] }
 tracing = "0.1.36"
 tracing-appender = "0.2.2"
-tracing-subscriber = { version = "0.3.15", features = ["std", "time", "registry", "env-filter"] }
 tracing-bunyan-formatter = "0.3.3"
-tracing-opentelemetry = { version = "0.17.4", optional = true }
-opentelemetry = { version = "0.17.0", features = ["rt-tokio"], optional = true }
-opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio"], optional = true }
-console-subscriber = { version = "0.1.6", optional = true }
 tracing-chrome = { version = "0.6.0", optional = true }
-once_cell = "1.13.0"
-crossterm = "0.25.0"
+tracing-opentelemetry = { version = "0.17.4", optional = true }
+tracing-subscriber = { version = "0.3.15", features = ["std", "time", "registry", "env-filter"] }
 
 [features]
 default = ["jaeger", "chrome"]

--- a/crates/typed-store-macros-tests/Cargo.toml
+++ b/crates/typed-store-macros-tests/Cargo.toml
@@ -8,22 +8,23 @@ repository = "https://github.com/mystenlabs/mysten-infra"
 edition = "2021"
 publish = false
 
-
 [dev-dependencies]
-syn = { version = "1.0.64", features = ["derive"] }
-quote = "1.0.9"
-proc-macro2 = "1.0.24"
-anyhow = { version = "1.0.58" }
-typed-store = {path = "../typed-store"}
-tempfile = "3.3.0"
-tokio = { version = "1.20.0", features = ["sync", "macros", "rt"] }
-typed-store-macros = { path = "../typed-store-macros"}
-rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
-eyre = "0.6.8"
-serde = { version = "1.0.139", features = ["derive"] }
 bincode = "1.3.3"
-tracing = "0.1.35"
-thiserror = "1.0.31"
 collectable = "0.0.2"
+eyre = "0.6.8"
 fdlimit = "0.2.1"
 pre = "0.2.0"
+proc-macro2 = "1.0.24"
+quote = "1.0.9"
+rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
+serde = { version = "1.0.139", features = ["derive"] }
+syn = { version = "1.0.64", features = ["derive"] }
+tempfile = "3.3.0"
+thiserror = "1.0.31"
+tokio = { version = "1.20.0", features = ["sync", "macros", "rt"] }
+tracing = "0.1.35"
+typed-store = { path = "../typed-store" }
+typed-store-macros = { path = "../typed-store-macros" }
+
+[dependencies]
+eyre = "0.6.8"

--- a/crates/typed-store-macros/Cargo.toml
+++ b/crates/typed-store-macros/Cargo.toml
@@ -12,16 +12,13 @@ publish = false
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.64", features = ["derive"] }
-quote = "1.0.9"
-proc-macro2 = "1.0.24"
-anyhow = { version = "1.0.58"}
-typed-store = {path = "../typed-store"}
-tokio = { version = "1.20.0", features = ["sync", "macros", "rt"] }
-tempfile = "3.3.0"
-rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
+eyre = "0.6.8"
 fdlimit = "0.2.1"
 pre = "0.2.0"
-
-[dev-dependencies]
-anyhow = "1.0.52"
+proc-macro2 = "1.0.24"
+quote = "1.0.9"
+rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
+syn = { version = "1.0.64", features = ["derive"] }
+tempfile = "3.3.0"
+tokio = { version = "1.20.0", features = ["sync", "macros", "rt"] }
+typed-store = { path = "../typed-store" }

--- a/crates/typed-store-macros/src/lib.rs
+++ b/crates/typed-store-macros/src/lib.rs
@@ -185,7 +185,7 @@ pub fn derive_dbmap_utils(input: TokenStream) -> TokenStream {
             /// TODO: use preconditions to ensure call after `open_tables_read_only`
             // #_precondition_str_tok
             fn dump(&self, table_name: &str, page_size: u16,
-                page_number: usize) -> anyhow::Result<std::collections::BTreeMap<String, String>> {
+                page_number: usize) -> eyre::Result<std::collections::BTreeMap<String, String>> {
                 Ok(match table_name {
                     #(
                         stringify!(#field_names) => {
@@ -198,7 +198,7 @@ pub fn derive_dbmap_utils(input: TokenStream) -> TokenStream {
                         }
                     )*
 
-                    _ => anyhow::bail!("No such table name: {}", table_name),
+                    _ => eyre::bail!("No such table name: {}", table_name),
                 })
             }
 
@@ -206,7 +206,7 @@ pub fn derive_dbmap_utils(input: TokenStream) -> TokenStream {
             /// Tables must be opened in read only mode using `open_tables_read_only`
             /// TODO: use preconditions to ensure call after `open_tables_read_only`
             // #_precondition_str_tok
-            fn count_keys(&self, table_name: &str) -> anyhow::Result<usize> {
+            fn count_keys(&self, table_name: &str) -> eyre::Result<usize> {
                 Ok(match table_name {
                     #(
                         stringify!(#field_names) => {
@@ -215,7 +215,7 @@ pub fn derive_dbmap_utils(input: TokenStream) -> TokenStream {
                         }
                     )*
 
-                    _ => anyhow::bail!("No such table name: {}", table_name),
+                    _ => eyre::bail!("No such table name: {}", table_name),
                 })
             }
         }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -9,19 +9,18 @@ edition = "2021"
 publish = false
 
 [dependencies]
-# deactivation of bzip2 due to https://github.com/rust-rocksdb/rust-rocksdb/issues/609
-rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
-eyre = "0.6.8"
-serde = { version = "1.0.140", features = ["derive"] }
 bincode = "1.3.3"
-tracing = "0.1.36"
-tokio = { version = "1.20.1", features = ["sync", "macros", "rt"] }
-thiserror = "1.0.31"
 collectable = "0.0.2"
+eyre = "0.6.8"
 fdlimit = "0.2.1"
-anyhow = { version = "1.0.58" }
 pre = "0.2.0"
 tap = "1.0.1"
+# deactivation of bzip2 due to https://github.com/rust-rocksdb/rust-rocksdb/issues/609
+rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
+serde = { version = "1.0.140", features = ["derive"] }
+thiserror = "1.0.31"
+tokio = { version = "1.20.1", features = ["sync", "macros", "rt"] }
+tracing = "0.1.36"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -107,17 +107,17 @@ pub trait DBMapTableUtil {
         table_name: &str,
         page_size: u16,
         page_number: usize,
-    ) -> anyhow::Result<BTreeMap<String, String>>;
+    ) -> eyre::Result<BTreeMap<String, String>>;
 
     /// Counts the keys in the table
     #[pre("Must be called only after `open_tables_read_only`")]
-    fn count_keys(&self, table_name: &str) -> anyhow::Result<usize>;
+    fn count_keys(&self, table_name: &str) -> eyre::Result<usize>;
 
     /// List all the tables at this path
     /// Tables must be opened in read only mode using `open_tables_read_only`
     /// TODO: use preconditions to ensure call after `open_tables_read_only`
     // #_precondition_str_tok
-    fn list_tables(path: std::path::PathBuf) -> anyhow::Result<Vec<String>> {
+    fn list_tables(path: std::path::PathBuf) -> eyre::Result<Vec<String>> {
         const DB_DEFAULT_CF_NAME: &str = "default";
 
         let opts = rocksdb::Options::default();

--- a/crates/x/Cargo.toml
+++ b/crates/x/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.58"
+clap = { version = "3.1.14", features = ["derive"] }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "5bf35a12bfaed45328288933e222006ee4e99c28" }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "5bf35a12bfaed45328288933e222006ee4e99c28" }
-clap = { version = "3.1.14", features = ["derive"] }


### PR DESCRIPTION
Better architecture of the import of `backtrace-rs`, which allows its use on stable (detail that hit us elsewhere).
Plenty of other features (colors in logs!), but mostly: unification of the libs we use across the architecture.