### PR TITLE
[typed-store] implement the prev() on iterator

### DIFF
--- a/crates/typed-store/src/rocks/iter.rs
+++ b/crates/typed-store/src/rocks/iter.rs
@@ -3,6 +3,7 @@
 use std::marker::PhantomData;
 
 use bincode::Options;
+use rocksdb::Direction;
 
 use super::{be_fix_int_ser, errors::TypedStoreError};
 use serde::{de::DeserializeOwned, Serialize};
@@ -13,6 +14,7 @@ use super::DBRawIteratorMultiThreaded;
 pub struct Iter<'a, K, V> {
     db_iter: DBRawIteratorMultiThreaded<'a>,
     _phantom: PhantomData<(K, V)>,
+    direction: Direction,
 }
 
 impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iter<'a, K, V> {
@@ -20,24 +22,7 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iter<'a, K, V> {
         Self {
             db_iter,
             _phantom: PhantomData,
-        }
-    }
-
-    pub fn prev(&mut self) -> Option<(K, V)> {
-        if self.db_iter.valid() {
-            let config = bincode::DefaultOptions::new()
-                .with_big_endian()
-                .with_fixint_encoding();
-            let key = self.db_iter.key().and_then(|k| config.deserialize(k).ok());
-            let value = self
-                .db_iter
-                .value()
-                .and_then(|v| bincode::deserialize(v).ok());
-
-            self.db_iter.prev();
-            key.and_then(|k| value.map(|v| (k, v)))
-        } else {
-            None
+            direction: Direction::Forward,
         }
     }
 }
@@ -56,7 +41,11 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for Iter<'a, K, V> {
                 .value()
                 .and_then(|v| bincode::deserialize(v).ok());
 
-            self.db_iter.next();
+            match self.direction {
+                Direction::Forward => self.db_iter.next(),
+                Direction::Reverse => self.db_iter.prev(),
+            }
+
             key.and_then(|k| value.map(|v| (k, v)))
         } else {
             None
@@ -85,5 +74,36 @@ impl<'a, K: Serialize, V> Iter<'a, K, V> {
     pub fn skip_to_last(mut self) -> Self {
         self.db_iter.seek_to_last();
         self
+    }
+
+    /// Will make the direction of the iteration reverse and will
+    /// create a new `RevIter` to consume. Every call to `next` method
+    /// will give the next element from the end.
+    pub fn reverse(mut self) -> RevIter<'a, K, V> {
+        self.direction = Direction::Reverse;
+        RevIter::new(self)
+    }
+}
+
+/// An iterator with a reverted direction to the original. The `RevIter`
+/// is hosting an iteration which is consuming in the opposing direction.
+/// It's not possible to do further manipulation (ex re-reverse) to the
+/// iterator.
+pub struct RevIter<'a, K, V> {
+    iter: Iter<'a, K, V>,
+}
+
+impl<'a, K, V> RevIter<'a, K, V> {
+    fn new(iter: Iter<'a, K, V>) -> Self {
+        Self { iter }
+    }
+}
+
+impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for RevIter<'a, K, V> {
+    type Item = (K, V);
+
+    /// Will give the next item backwards
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
     }
 }

--- a/crates/typed-store/src/rocks/iter.rs
+++ b/crates/typed-store/src/rocks/iter.rs
@@ -22,6 +22,24 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iter<'a, K, V> {
             _phantom: PhantomData,
         }
     }
+
+    pub fn prev(&mut self) -> Option<(K, V)> {
+        if self.db_iter.valid() {
+            let config = bincode::DefaultOptions::new()
+                .with_big_endian()
+                .with_fixint_encoding();
+            let key = self.db_iter.key().and_then(|k| config.deserialize(k).ok());
+            let value = self
+                .db_iter
+                .value()
+                .and_then(|v| bincode::deserialize(v).ok());
+
+            self.db_iter.prev();
+            key.and_then(|k| value.map(|v| (k, v)))
+        } else {
+            None
+        }
+    }
 }
 
 impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for Iter<'a, K, V> {

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -234,18 +234,23 @@ fn test_iter() {
 }
 
 #[test]
-fn test_iter_prev() {
+fn test_iter_reverse() {
     let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
 
     db.insert(&1, &"1".to_string()).expect("Failed to insert");
     db.insert(&2, &"2".to_string()).expect("Failed to insert");
     db.insert(&3, &"3".to_string()).expect("Failed to insert");
 
-    let mut iter = db.iter().skip_to_last();
-    assert_eq!(Some((3, "3".to_string())), iter.prev());
-    assert_eq!(Some((2, "2".to_string())), iter.prev());
-    assert_eq!(Some((1, "1".to_string())), iter.prev());
-    assert_eq!(None, iter.prev());
+    let mut iter = db.iter().skip_to_last().reverse();
+    assert_eq!(Some((3, "3".to_string())), iter.next());
+    assert_eq!(Some((2, "2".to_string())), iter.next());
+    assert_eq!(Some((1, "1".to_string())), iter.next());
+    assert_eq!(None, iter.next());
+
+    let mut iter = db.iter().skip_to(&2).unwrap().reverse();
+    assert_eq!(Some((2, "2".to_string())), iter.next());
+    assert_eq!(Some((1, "1".to_string())), iter.next());
+    assert_eq!(None, iter.next());
 }
 
 #[test]

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -234,6 +234,21 @@ fn test_iter() {
 }
 
 #[test]
+fn test_iter_prev() {
+    let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
+
+    db.insert(&1, &"1".to_string()).expect("Failed to insert");
+    db.insert(&2, &"2".to_string()).expect("Failed to insert");
+    db.insert(&3, &"3".to_string()).expect("Failed to insert");
+
+    let mut iter = db.iter().skip_to_last();
+    assert_eq!(Some((3, "3".to_string())), iter.prev());
+    assert_eq!(Some((2, "2".to_string())), iter.prev());
+    assert_eq!(Some((1, "1".to_string())), iter.prev());
+    assert_eq!(None, iter.prev());
+}
+
+#[test]
 fn test_keys() {
     let db = DBMap::open(temp_dir(), None, None).expect("Failed to open storage");
 


### PR DESCRIPTION
Introduces the method `prev()` on the iterator used by the `DBMap` so we can retrieve our results in reverse order. That's particularly useful in situations where you want to `skip_to_last` element and start retrieving the elements backwards.