### PR TITLE
[Feature][Telemetry] Automatic span latency measurement

### DIFF
--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-chrono = "0.4.0"
 console-subscriber = { version = "0.1.6", optional = true }
 crossterm = "0.25.0"
 once_cell = "1.13.0"

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -9,11 +9,13 @@ edition = "2021"
 publish = false
 
 [dependencies]
+chrono = "0.4.0"
 console-subscriber = { version = "0.1.6", optional = true }
 crossterm = "0.25.0"
 once_cell = "1.13.0"
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"], optional = true }
 opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio"], optional = true }
+prometheus = "0.13.1"
 tokio = { version = "1.20.1", features = ["sync", "macros", "rt", "rt-multi-thread"] }
 tracing = "0.1.36"
 tracing-appender = "0.2.2"

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -34,12 +34,14 @@ use tracing_subscriber::{
 
 use crossterm::tty::IsTty;
 
+pub mod span_latency_prom;
+
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// Configuration for different logging/tracing options
 /// ===
-/// - json_log_output: Output JSON logs to stdout only.  No other options will work.
+/// - json_log_output: Output JSON logs to stdout only.
 /// - log_file: If defined, write output to a file starting with this name, ex app.log
 /// - log_level: error/warn/info/debug/trace, defaults to info
 /// - service_name:
@@ -49,8 +51,9 @@ pub struct TelemetryConfig {
     pub service_name: String,
 
     pub enable_tracing: bool,
+    /// Enables Tokio Console debugging on port 6669
     pub tokio_console: bool,
-    /// Output JSON logs.  Tracing and Tokio Console are not available if this is enabled.
+    /// Output JSON logs.
     pub json_log_output: bool,
     /// Write chrome trace output, which can be loaded from chrome://tracing
     pub chrome_trace_output: bool,

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -354,8 +354,6 @@ mod tests {
         assert_eq!(labels[0].get_value(), "yo span yo");
 
         panic!("This should cause error logs to be printed out!");
-
-        // Now, latencies from the span should be visible in the registry
     }
 
     /*

--- a/crates/telemetry-subscribers/src/span_latency_prom.rs
+++ b/crates/telemetry-subscribers/src/span_latency_prom.rs
@@ -12,6 +12,9 @@
 //!   is already using Prometheus
 //! Thus this is a much smaller and more focused module.
 //!
+//! ## Making spans visible
+//! This module can only record latencies for spans that get created.  By default, this is controlled by
+//! env_filter and logging levels.
 
 use chrono::offset::Utc;
 use prometheus::{exponential_buckets, register_histogram_vec_with_registry, Registry};

--- a/crates/telemetry-subscribers/src/span_latency_prom.rs
+++ b/crates/telemetry-subscribers/src/span_latency_prom.rs
@@ -76,6 +76,10 @@ where
         ctx: tracing_subscriber::layer::Context<S>,
     ) {
         let span = ctx.span(id).unwrap();
+        // NOTE: there are other extensions that insert timings.  For example,
+        // tracing_subscriber's with_span_events() inserts events at open and close that contain timings.
+        // However, we cannot be guaranteed that those events would be turned on.
+        // TODO: maybe add a check if something else is already inserted...
         span.extensions_mut()
             .insert(PromSpanTimestamp(Utc::now().timestamp()));
     }

--- a/crates/telemetry-subscribers/src/span_latency_prom.rs
+++ b/crates/telemetry-subscribers/src/span_latency_prom.rs
@@ -100,3 +100,17 @@ where
             .observe(elapsed_ns as f64);
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prom_span_latency_init() {
+        let registry = prometheus::Registry::new();
+
+        let res = PrometheusSpanLatencyLayer::try_new(&registry, 0);
+        assert!(matches!(res, Err(PrometheusSpanError::ZeroOrNegativeNumBuckets)));
+    }
+}

--- a/crates/telemetry-subscribers/src/span_latency_prom.rs
+++ b/crates/telemetry-subscribers/src/span_latency_prom.rs
@@ -3,6 +3,8 @@
 
 //! This is a module that records Tokio-tracing [span](https://docs.rs/tracing/latest/tracing/span/index.html)
 //! latencies into Prometheus histograms directly.
+//! The name of the Prometheus histogram is "tracing_span_latencies[_sum/count/bucket]"
+//!
 //! There is also the tracing-timing crate, from which this differs significantly:
 //! - tracing-timing records latencies between events (logs).  We just want to record the latencies of spans.
 //! - tracing-timing does not output to Prometheus, and extracting data from its histograms takes extra CPU
@@ -20,6 +22,7 @@ pub struct PrometheusSpanLatencyLayer {
     span_latencies: prometheus::HistogramVec,
 }
 
+#[derive(Debug)]
 pub enum PrometheusSpanError {
     /// num_buckets must be positive >= 1
     ZeroOrNegativeNumBuckets,

--- a/crates/telemetry-subscribers/src/span_latency_prom.rs
+++ b/crates/telemetry-subscribers/src/span_latency_prom.rs
@@ -1,0 +1,92 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This is a module that records Tokio-tracing [span](https://docs.rs/tracing/latest/tracing/span/index.html)
+//! latencies into Prometheus histograms directly.
+//! There is also the tracing-timing crate, from which this differs significantly:
+//! - tracing-timing records latencies between events (logs).  We just want to record the latencies of spans.
+//! - tracing-timing does not output to Prometheus, and extracting data from its histograms takes extra CPU
+//! - tracing-timing records latencies using HDRHistogram, which is great, but uses extra memory when one
+//!   is already using Prometheus
+//! Thus this is a much smaller and more focused module.
+//!
+
+use chrono::offset::Utc;
+use prometheus::{exponential_buckets, register_histogram_vec_with_registry, Registry};
+use tracing::{span, Subscriber};
+
+/// A tokio_tracing Layer that records span latencies into Prometheus histograms
+pub struct PrometheusSpanLatencyLayer {
+    span_latencies: prometheus::HistogramVec,
+}
+
+pub enum PrometheusSpanError {
+    /// num_buckets must be positive >= 1
+    ZeroOrNegativeNumBuckets,
+    PromError(prometheus::Error),
+}
+
+impl From<prometheus::Error> for PrometheusSpanError {
+    fn from(err: prometheus::Error) -> Self {
+        Self::PromError(err)
+    }
+}
+
+const TOP_LATENCY_IN_NS: f64 = 300.0 * 1.0e9;
+const LOWEST_LATENCY_IN_NS: f64 = 500.0;
+
+impl PrometheusSpanLatencyLayer {
+    /// Create a new layer, injecting latencies into the given registry.
+    /// The num_buckets controls how many buckets thus how much memory and time series one
+    /// uses up in Prometheus (and in the application).  10 is probably a minimum.
+    pub fn try_new(registry: &Registry, num_buckets: usize) -> Result<Self, PrometheusSpanError> {
+        if num_buckets < 1 {
+            return Err(PrometheusSpanError::ZeroOrNegativeNumBuckets);
+        }
+
+        // Histogram for span latencies must accommodate a wide range of possible latencies, so
+        // don't use the default Prometheus buckets
+        // The latencies are in nanoseconds
+        let factor = (TOP_LATENCY_IN_NS / LOWEST_LATENCY_IN_NS).powf(1.0 / (num_buckets as f64));
+        let buckets = exponential_buckets(LOWEST_LATENCY_IN_NS, factor, num_buckets)?;
+        let span_latencies = register_histogram_vec_with_registry!(
+            "tracing_span_latencies",
+            "Latencies from tokio-tracing spans",
+            &["span_name"],
+            buckets,
+            registry
+        )?;
+        Ok(Self { span_latencies })
+    }
+}
+
+struct PromSpanTimestamp(i64);
+
+impl<S> tracing_subscriber::Layer<S> for PrometheusSpanLatencyLayer
+where
+    S: Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    fn on_new_span(
+        &self,
+        _attrs: &span::Attributes,
+        id: &span::Id,
+        ctx: tracing_subscriber::layer::Context<S>,
+    ) {
+        let span = ctx.span(id).unwrap();
+        span.extensions_mut()
+            .insert(PromSpanTimestamp(Utc::now().timestamp()));
+    }
+
+    fn on_close(&self, id: span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let span = ctx.span(&id).unwrap();
+        let start_time = span
+            .extensions()
+            .get::<PromSpanTimestamp>()
+            .expect("Could not find saved timestamp on span")
+            .0;
+        let elapsed_ns = Utc::now().timestamp() - start_time;
+        self.span_latencies
+            .with_label_values(&[span.name()])
+            .observe(elapsed_ns as f64);
+    }
+}

--- a/crates/telemetry-subscribers/src/span_latency_prom.rs
+++ b/crates/telemetry-subscribers/src/span_latency_prom.rs
@@ -101,7 +101,6 @@ where
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,6 +110,9 @@ mod tests {
         let registry = prometheus::Registry::new();
 
         let res = PrometheusSpanLatencyLayer::try_new(&registry, 0);
-        assert!(matches!(res, Err(PrometheusSpanError::ZeroOrNegativeNumBuckets)));
+        assert!(matches!(
+            res,
+            Err(PrometheusSpanError::ZeroOrNegativeNumBuckets)
+        ));
     }
 }


### PR DESCRIPTION
This PR adds a custom `tracing` `Layer` that records the latency of every `Span` into a Prometheus Histogram.
A label `span_name` contains the name of the span, so one can easily search for latency stats for a particular span they are interested in.

The memory usage of this layer is one Prometheus Histogram (with a configurable number of buckets, but at least 10 is recommended) per declared span in the codebase.

This PR should make it vastly easier to track the running latency statistics of any tracing span declared in an application.