### PR TITLE
rename get_or_insert to indicate unsafe

### DIFF
--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -21,7 +21,12 @@ where
 
     /// Returns the value for the given key from the map, if it exists
     /// or the given default value if it does not.
-    fn get_or_insert<F: FnOnce() -> V>(&self, key: &K, default: F) -> Result<V, Self::Error> {
+    /// This method is not thread safe
+    fn get_or_insert_unsafe<F: FnOnce() -> V>(
+        &self,
+        key: &K,
+        default: F,
+    ) -> Result<V, Self::Error> {
         self.get(key).and_then(|optv| match optv {
             Some(v) => Ok(v),
             None => {


### PR DESCRIPTION
As noted [here](https://github.com/MystenLabs/sui/issues/6010), get_or_insert is not thread safe, so while we work on making it so, we should mark it as unsafe.