### PR TITLE
Add a `ClosureMetric` for Prometheus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/mysten-util-mem",
     "crates/mysten-util-mem-derive",
     "crates/name-variant",
+    "crates/prometheus-closure-metric",
     "crates/rccheck",
     "crates/telemetry-subscribers",
     "crates/typed-store",

--- a/crates/prometheus-closure-metric/Cargo.toml
+++ b/crates/prometheus-closure-metric/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "prometheus-closure-metric"
+version = "0.1.0"
+authors = ["Andrew Schran <aschran@mystenlabs.com>"]
+repository = "https://github.com/mystenlabs/mysten-infra"
+description = "Library for a Prometheus metric that computes its value by given closure at collection time"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0.58"
+prometheus = "0.13.1"
+protobuf = "^2.0"

--- a/crates/prometheus-closure-metric/src/lib.rs
+++ b/crates/prometheus-closure-metric/src/lib.rs
@@ -15,6 +15,10 @@ use anyhow::Result;
 use prometheus::core;
 use prometheus::proto;
 
+/// A Prometheus metric whose value is computed at collection time by the provided closure.
+///
+/// WARNING: The provided closure must be fast (~milliseconds or faster), since it blocks
+/// metric collection.
 #[derive(Debug)]
 pub struct ClosureMetric<F> {
     desc: core::Desc,

--- a/crates/prometheus-closure-metric/src/lib.rs
+++ b/crates/prometheus-closure-metric/src/lib.rs
@@ -1,0 +1,134 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2014 The Prometheus Authors
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! This library implements a `ClosureMetric` for crate `prometheus` whose value is computed at
+//! the time of collection by a provided closure.
+
+// TODO: add example usage once constructor macros are implemented.
+// (For now, look at tests for an example.)
+
+use anyhow::anyhow;
+use anyhow::Result;
+use prometheus::core;
+use prometheus::proto;
+
+#[derive(Debug)]
+pub struct ClosureMetric<F> {
+    desc: core::Desc,
+    f: F,
+    value_type: ValueType,
+    label_pairs: Vec<proto::LabelPair>,
+}
+
+impl<F, T> ClosureMetric<F>
+where
+    F: Fn() -> T + Sync + Send,
+    T: core::Number,
+{
+    pub fn new<D: core::Describer>(
+        describer: D,
+        value_type: ValueType,
+        f: F,
+        label_values: &[&str],
+    ) -> Result<Self> {
+        let desc = describer.describe()?;
+        let label_pairs = make_label_pairs(&desc, label_values)?;
+
+        Ok(Self {
+            desc,
+            f,
+            value_type,
+            label_pairs,
+        })
+    }
+
+    pub fn metric(&self) -> proto::Metric {
+        let mut m = proto::Metric::default();
+        m.set_label(protobuf::RepeatedField::from_vec(self.label_pairs.clone()));
+
+        let val = (self.f)().into_f64();
+        match self.value_type {
+            ValueType::Counter => {
+                let mut counter = proto::Counter::default();
+                counter.set_value(val);
+                m.set_counter(counter);
+            }
+            ValueType::Gauge => {
+                let mut gauge = proto::Gauge::default();
+                gauge.set_value(val);
+                m.set_gauge(gauge);
+            }
+        }
+
+        m
+    }
+}
+
+impl<F, T> prometheus::core::Collector for ClosureMetric<F>
+where
+    F: Fn() -> T + Sync + Send,
+    T: core::Number,
+{
+    fn desc(&self) -> Vec<&prometheus::core::Desc> {
+        vec![&self.desc]
+    }
+
+    fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
+        let mut m = proto::MetricFamily::default();
+        m.set_name(self.desc.fq_name.clone());
+        m.set_help(self.desc.help.clone());
+        m.set_field_type(self.value_type.metric_type());
+        m.set_metric(protobuf::RepeatedField::from_vec(vec![self.metric()]));
+        vec![m]
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ValueType {
+    Counter,
+    Gauge,
+}
+
+impl ValueType {
+    /// `metric_type` returns the corresponding proto metric type.
+    pub fn metric_type(self) -> proto::MetricType {
+        match self {
+            ValueType::Counter => proto::MetricType::COUNTER,
+            ValueType::Gauge => proto::MetricType::GAUGE,
+        }
+    }
+}
+
+pub fn make_label_pairs(desc: &core::Desc, label_values: &[&str]) -> Result<Vec<proto::LabelPair>> {
+    if desc.variable_labels.len() != label_values.len() {
+        return Err(anyhow!("inconsistent cardinality"));
+    }
+
+    let total_len = desc.variable_labels.len() + desc.const_label_pairs.len();
+    if total_len == 0 {
+        return Ok(vec![]);
+    }
+
+    if desc.variable_labels.is_empty() {
+        return Ok(desc.const_label_pairs.clone());
+    }
+
+    let mut label_pairs = Vec::with_capacity(total_len);
+    for (i, n) in desc.variable_labels.iter().enumerate() {
+        let mut label_pair = proto::LabelPair::default();
+        label_pair.set_name(n.clone());
+        label_pair.set_value(label_values[i].to_owned());
+        label_pairs.push(label_pair);
+    }
+
+    for label_pair in &desc.const_label_pairs {
+        label_pairs.push(label_pair.clone());
+    }
+    label_pairs.sort();
+    Ok(label_pairs)
+}
+
+// TODO: add and test macros for easier ClosureMetric construction.

--- a/crates/prometheus-closure-metric/tests/closure_metric.rs
+++ b/crates/prometheus-closure-metric/tests/closure_metric.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus_closure_metric::ClosureMetric;
+
+#[test]
+fn closure_metric_basic() {
+    let opts =
+        prometheus::opts!("my_closure_metric", "A test closure metric",).variable_label("my_label");
+
+    let fn_42 = || 42_u64;
+    let metric0 = ClosureMetric::new(
+        opts,
+        prometheus_closure_metric::ValueType::Gauge,
+        fn_42,
+        &["forty_two"],
+    )
+    .unwrap();
+
+    assert!(prometheus::default_registry()
+        .register(Box::new(metric0))
+        .is_ok());
+
+    // Gather the metrics.
+    let metric_families = prometheus::default_registry().gather();
+    assert_eq!(1, metric_families.len());
+    let metric_family = &metric_families[0];
+    assert_eq!("my_closure_metric", metric_family.get_name());
+    let metric = metric_family.get_metric();
+    assert_eq!(1, metric.len());
+    assert_eq!(42.0, metric[0].get_gauge().get_value());
+    let labels = metric[0].get_label();
+    assert_eq!(1, labels.len());
+    assert_eq!("my_label", labels[0].get_name());
+    assert_eq!("forty_two", labels[0].get_value());
+}


### PR DESCRIPTION
Implements a `ClosureMetric` for crate `prometheus` whose value is computed at the time of collection by a provided closure.