### PR TITLE
feat(typed-store): default implementations for `Map::multi_*`

### DIFF
--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -61,12 +61,12 @@ where
     fn values(&'a self) -> Self::Values;
 
     /// Returns a vector of values corresponding to the keys provided.
-    fn multi_get<J>(
-        &self,
-        keys: impl IntoIterator<Item = J>,
-    ) -> Result<Vec<Option<V>>, Self::Error>
+    fn multi_get<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<Vec<Option<V>>, Self::Error>
     where
-        J: Borrow<K>;
+        J: Borrow<K>,
+    {
+        keys.into_iter().map(|key| self.get(key.borrow())).collect()
+    }
 
     /// Inserts key-value pairs.
     fn multi_insert<J, U>(
@@ -75,12 +75,21 @@ where
     ) -> Result<(), Self::Error>
     where
         J: Borrow<K>,
-        U: Borrow<V>;
+        U: Borrow<V>,
+    {
+        key_val_pairs
+            .into_iter()
+            .try_for_each(|(key, value)| self.insert(key.borrow(), value.borrow()))
+    }
 
     /// Removes keys.
     fn multi_remove<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<(), Self::Error>
     where
-        J: Borrow<K>;
+        J: Borrow<K>,
+    {
+        keys.into_iter()
+            .try_for_each(|key| self.remove(key.borrow()))
+    }
 
     /// Try to catch up with primary when running as secondary
     fn try_catch_up_with_primary(&self) -> Result<(), Self::Error>;

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -60,7 +60,7 @@ where
     /// Returns an iterator over each value in the map.
     fn values(&'a self) -> Self::Values;
 
-    /// Returns a vector of values corresponding to the keys provided.
+    /// Returns a vector of values corresponding to the keys provided, non-atomically.
     fn multi_get<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<Vec<Option<V>>, Self::Error>
     where
         J: Borrow<K>,
@@ -68,7 +68,7 @@ where
         keys.into_iter().map(|key| self.get(key.borrow())).collect()
     }
 
-    /// Inserts key-value pairs.
+    /// Inserts key-value pairs, non-atomically.
     fn multi_insert<J, U>(
         &self,
         key_val_pairs: impl IntoIterator<Item = (J, U)>,
@@ -82,7 +82,7 @@ where
             .try_for_each(|(key, value)| self.insert(key.borrow(), value.borrow()))
     }
 
-    /// Removes keys.
+    /// Removes keys, non-atomically.
     fn multi_remove<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<(), Self::Error>
     where
         J: Borrow<K>,


### PR DESCRIPTION
Fixes #40 by providing default implementations for `Map::{multi_get, multi_insert, multi_remove}`. 

If there are plans to provide the trait with more default implementations, then it could be judicious to have a stub `SomeMap` structure implementing `Map` so that we can write tests.