### PR TITLE
Add sampling for metrics reporting

### DIFF
--- a/crates/typed-store-derive/Cargo.toml
+++ b/crates/typed-store-derive/Cargo.toml
@@ -15,9 +15,11 @@ proc-macro = true
 proc-macro2 = "1.0.47"
 quote = "1.0.9"
 syn = { version = "1.0.102", features = ["derive"] }
+tokio = { version = "1.21.2", features = ["full"] }
 
 [dev-dependencies]
 eyre = "0.6.8"
 rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
 tempfile = "3.3.0"
 typed-store = { path = "../typed-store" }
+tokio = { version = "1.21.2", features = ["test-util"] }

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -172,6 +172,7 @@ fn extract_generics_names(generics: &Generics) -> Vec<Ident> {
 /// use typed_store::Store;
 /// use typed_store_derive::DBMapUtils;
 /// use typed_store::traits::TypedStoreDebug;
+/// use core::fmt::Error;
 /// /// Define a struct with all members having type DBMap<K, V>
 ///
 /// fn custom_fn_name1() -> DBOptions {DBOptions::default()}
@@ -197,6 +198,8 @@ fn extract_generics_names(generics: &Generics) -> Vec<Ident> {
 /// // For finer control, we also allow the opener of the DB to specify their own options which override the defaults set by the definer
 /// // This is done via a configurator which gives one a struct with field similarly named as that of the DB, but of type Options
 ///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Error> {
 /// // Get a configurator for this table
 /// let mut config = Tables::configurator();
 /// // Config table 1
@@ -208,6 +211,8 @@ fn extract_generics_names(generics: &Generics) -> Vec<Ident> {
 ///
 /// // We can then open the DB with the configs
 /// let _ = Tables::open_tables_read_write(primary_path, None, Some(config.build()));
+/// Ok(())
+/// }
 ///
 ///```
 ///
@@ -224,6 +229,7 @@ fn extract_generics_names(generics: &Generics) -> Vec<Ident> {
 /// use typed_store::Store;
 /// use typed_store_derive::DBMapUtils;
 /// use typed_store::traits::TypedStoreDebug;
+/// use core::fmt::Error;
 /// /// Define a struct with all members having type DBMap<K, V>
 ///
 /// fn custom_fn_name1() -> DBOptions {DBOptions::default()}
@@ -244,6 +250,8 @@ fn extract_generics_names(generics: &Generics) -> Vec<Ident> {
 ///     #[default_options_override_fn = "custom_fn_name1"]
 ///     table4: DBMap<i32, String>,
 /// }
+/// #[tokio::main]
+/// async fn main() -> Result<(), Error> {
 ///
 /// let primary_path = tempfile::tempdir().expect("Failed to open temporary directory").into_path();
 /// let _ = Tables::open_tables_read_write(primary_path.clone(), None, None);
@@ -253,6 +261,8 @@ fn extract_generics_names(generics: &Generics) -> Vec<Ident> {
 /// // Use this handle for dumping
 /// let ret = read_only_handle.dump("table2", 100, 0).unwrap();
 /// let key_count = read_only_handle.count_keys("table1").unwrap();
+/// Ok(())
+/// }
 /// ```
 /// 4. Auto-generated memory stats method
 /// `self.get_memory_usage` is derived to provide memory and cache usage

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -20,7 +20,7 @@ prometheus = "0.13.2"
 rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
 serde = { version = "1.0.140", features = ["derive"] }
 thiserror = "1.0.37"
-tokio = { version = "1.21.2", features = ["sync", "macros", "rt"] }
+tokio = { version = "1.21.2", features = ["full", "test-util"] }
 tracing = "0.1.37"
 
 [dev-dependencies]

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -9,14 +9,14 @@ fn temp_dir() -> std::path::PathBuf {
         .into_path()
 }
 
-#[test]
-fn test_open() {
+#[tokio::test]
+async fn test_open() {
     let _db = DBMap::<u32, String>::open(temp_dir(), None, None, &Registry::new())
         .expect("Failed to open storage");
 }
 
-#[test]
-fn test_reopen() {
+#[tokio::test]
+async fn test_reopen() {
     let arc = {
         let db = DBMap::<u32, String>::open(temp_dir(), None, None, &Registry::new())
             .expect("Failed to open storage");
@@ -31,8 +31,8 @@ fn test_reopen() {
         .expect("Failed to retrieve item in storage"));
 }
 
-#[test]
-fn test_reopen_macro() {
+#[tokio::test]
+async fn test_reopen_macro() {
     const FIRST_CF: &str = "First_CF";
     const SECOND_CF: &str = "Second_CF";
 
@@ -50,8 +50,8 @@ fn test_reopen_macro() {
     assert!(db_map_2.multi_insert(keys_vals_cf2).is_ok());
 }
 
-#[test]
-fn test_wrong_reopen() {
+#[tokio::test]
+async fn test_wrong_reopen() {
     let rocks = open_cf(temp_dir(), None, &["foo", "bar", "baz"]).unwrap();
     let db = DBMap::<u8, u8>::reopen(
         &rocks,
@@ -61,8 +61,8 @@ fn test_wrong_reopen() {
     assert!(db.is_err());
 }
 
-#[test]
-fn test_contains_key() {
+#[tokio::test]
+async fn test_contains_key() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
     db.insert(&123456789, &"123456789".to_string())
@@ -75,8 +75,8 @@ fn test_contains_key() {
         .expect("Failed to call contains key"));
 }
 
-#[test]
-fn test_get() {
+#[tokio::test]
+async fn test_get() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
     db.insert(&123456789, &"123456789".to_string())
@@ -88,8 +88,8 @@ fn test_get() {
     assert_eq!(None, db.get(&000000000).expect("Failed to get"));
 }
 
-#[test]
-fn test_get_raw() {
+#[tokio::test]
+async fn test_get_raw() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
     db.insert(&123456789, &"123456789".to_string())
@@ -111,8 +111,8 @@ fn test_get_raw() {
     );
 }
 
-#[test]
-fn test_multi_get() {
+#[tokio::test]
+async fn test_multi_get() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
     db.insert(&123, &"123".to_string())
@@ -128,8 +128,8 @@ fn test_multi_get() {
     assert_eq!(result[2], None);
 }
 
-#[test]
-fn test_skip() {
+#[tokio::test]
+async fn test_skip() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
     db.insert(&123, &"123".to_string())
@@ -169,8 +169,8 @@ fn test_skip() {
     assert_eq!(db.keys().skip_to(&000).expect("Skip failed").count(), 3);
 }
 
-#[test]
-fn test_skip_to_previous_simple() {
+#[tokio::test]
+async fn test_skip_to_previous_simple() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
     db.insert(&123, &"123".to_string())
@@ -210,8 +210,8 @@ fn test_skip_to_previous_simple() {
     );
 }
 
-#[test]
-fn test_iter_skip_to_previous_gap() {
+#[tokio::test]
+async fn test_iter_skip_to_previous_gap() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
     for i in 1..100 {
         if i != 50 {
@@ -238,8 +238,8 @@ fn test_iter_skip_to_previous_gap() {
     );
 }
 
-#[test]
-fn test_remove() {
+#[tokio::test]
+async fn test_remove() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
     db.insert(&123456789, &"123456789".to_string())
@@ -250,8 +250,8 @@ fn test_remove() {
     assert!(db.get(&123456789).expect("Failed to get").is_none());
 }
 
-#[test]
-fn test_iter() {
+#[tokio::test]
+async fn test_iter() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
     db.insert(&123456789, &"123456789".to_string())
@@ -262,8 +262,8 @@ fn test_iter() {
     assert_eq!(None, iter.next());
 }
 
-#[test]
-fn test_iter_reverse() {
+#[tokio::test]
+async fn test_iter_reverse() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
     db.insert(&1, &"1".to_string()).expect("Failed to insert");
@@ -282,8 +282,8 @@ fn test_iter_reverse() {
     assert_eq!(None, iter.next());
 }
 
-#[test]
-fn test_keys() {
+#[tokio::test]
+async fn test_keys() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
     db.insert(&123456789, &"123456789".to_string())
@@ -294,8 +294,8 @@ fn test_keys() {
     assert_eq!(None, keys.next());
 }
 
-#[test]
-fn test_values() {
+#[tokio::test]
+async fn test_values() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
     db.insert(&123456789, &"123456789".to_string())
@@ -306,8 +306,8 @@ fn test_values() {
     assert_eq!(None, values.next());
 }
 
-#[test]
-fn test_try_extend() {
+#[tokio::test]
+async fn test_try_extend() {
     let mut db =
         DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
     let mut keys_vals = (1..100).map(|i| (i, i.to_string()));
@@ -320,8 +320,8 @@ fn test_try_extend() {
     }
 }
 
-#[test]
-fn test_try_extend_from_slice() {
+#[tokio::test]
+async fn test_try_extend_from_slice() {
     let mut db =
         DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
     let keys_vals = (1..100).map(|i| (i, i.to_string()));
@@ -334,8 +334,8 @@ fn test_try_extend_from_slice() {
     }
 }
 
-#[test]
-fn test_insert_batch() {
+#[tokio::test]
+async fn test_insert_batch() {
     let db = DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
     let keys_vals = (1..100).map(|i| (i, i.to_string()));
     let insert_batch = db
@@ -349,8 +349,8 @@ fn test_insert_batch() {
     }
 }
 
-#[test]
-fn test_insert_batch_across_cf() {
+#[tokio::test]
+async fn test_insert_batch_across_cf() {
     let rocks = open_cf(temp_dir(), None, &["First_CF", "Second_CF"]).unwrap();
 
     let db_cf_1 = DBMap::reopen(
@@ -388,8 +388,8 @@ fn test_insert_batch_across_cf() {
     }
 }
 
-#[test]
-fn test_insert_batch_across_different_db() {
+#[tokio::test]
+async fn test_insert_batch_across_different_db() {
     let rocks = open_cf(temp_dir(), None, &["First_CF", "Second_CF"]).unwrap();
     let rocks2 = open_cf(temp_dir(), None, &["First_CF", "Second_CF"]).unwrap();
 
@@ -417,8 +417,8 @@ fn test_insert_batch_across_different_db() {
         .is_err());
 }
 
-#[test]
-fn test_delete_batch() {
+#[tokio::test]
+async fn test_delete_batch() {
     let db = DBMap::<i32, String>::open(temp_dir(), None, None, &Registry::new())
         .expect("Failed to open storage");
 
@@ -441,8 +441,8 @@ fn test_delete_batch() {
     }
 }
 
-#[test]
-fn test_delete_range() {
+#[tokio::test]
+async fn test_delete_range() {
     let db: DBMap<i32, String> =
         DBMap::open(temp_dir(), None, None, &Registry::new()).expect("Failed to open storage");
 
@@ -470,8 +470,8 @@ fn test_delete_range() {
     assert!(db.contains_key(&100).expect("Failed to query legel key"));
 }
 
-#[test]
-fn test_clear() {
+#[tokio::test]
+async fn test_clear() {
     let db = DBMap::<i32, String>::open(temp_dir(), None, Some("table"), &Registry::new())
         .expect("Failed to open storage");
     // Test clear of empty map
@@ -499,8 +499,8 @@ fn test_clear() {
     assert_eq!(db.iter().count(), 0);
 }
 
-#[test]
-fn test_is_empty() {
+#[tokio::test]
+async fn test_is_empty() {
     let db = DBMap::<i32, String>::open(temp_dir(), None, Some("table"), &Registry::new())
         .expect("Failed to open storage");
 
@@ -527,8 +527,8 @@ fn test_is_empty() {
     assert!(db.is_empty());
 }
 
-#[test]
-fn test_multi_insert() {
+#[tokio::test]
+async fn test_multi_insert() {
     // Init a DB
     let db = DBMap::<i32, String>::open(temp_dir(), None, Some("table"), &Registry::new())
         .expect("Failed to open storage");
@@ -544,8 +544,8 @@ fn test_multi_insert() {
     }
 }
 
-#[test]
-fn test_multi_remove() {
+#[tokio::test]
+async fn test_multi_remove() {
     // Init a DB
     let db = DBMap::<i32, String>::open(temp_dir(), None, Some("table"), &Registry::new())
         .expect("Failed to open storage");


### PR DESCRIPTION
We should have some sampling to not degrade perf by collecting (by enabling perf context mode in rocksdb) and updating prometheus metrics for dozens of rocksdb perf context counters from every thread. 
This PR allows for configurable sampling and default is 1 sample per second per DBMap.