### PR TITLE
Sadhan/add_cf_metrics

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -342,6 +342,13 @@ impl DBMetrics {
         }
     }
     pub fn make_db_metrics(registry: &Registry) -> &'static Arc<DBMetrics> {
+        // TODO: Remove static because this basically means we can
+        // only ever initialize db metrics once with a registry whereas
+        // in the code we might be trying to initialize it with different
+        // registries. The problem is underlying metrics cannot be re-initialized
+        // or prometheus complains. We essentially need metrics per column family
+        // but that might cause an explosion of metrics and hence a better way
+        // to do this is desired
         static ONCE: OnceCell<Arc<DBMetrics>> = OnceCell::new();
         ONCE.get_or_init(|| Arc::new(DBMetrics::new(registry)))
     }

--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -3,7 +3,8 @@
 use once_cell::sync::OnceCell;
 use prometheus::{
     exponential_buckets, register_histogram_vec_with_registry,
-    register_int_counter_vec_with_registry, HistogramVec, IntCounterVec, Registry,
+    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry, HistogramVec,
+    IntCounterVec, IntGaugeVec, Registry,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -57,7 +58,157 @@ impl SamplingInterval {
 }
 
 #[derive(Debug)]
-pub struct DBMetrics {
+pub struct ColumnFamilyMetrics {
+    pub rocksdb_total_sst_files_size: IntGaugeVec,
+    pub rocksdb_size_all_mem_tables: IntGaugeVec,
+    pub rocksdb_num_snapshots: IntGaugeVec,
+    pub rocksdb_oldest_snapshot_time: IntGaugeVec,
+    pub rocksdb_actual_delayed_write_rate: IntGaugeVec,
+    pub rocksdb_is_write_stopped: IntGaugeVec,
+    pub rocksdb_block_cache_capacity: IntGaugeVec,
+    pub rocksdb_block_cache_usage: IntGaugeVec,
+    pub rocksdb_block_cache_pinned_usage: IntGaugeVec,
+    pub rocskdb_estimate_table_readers_mem: IntGaugeVec,
+    pub rocksdb_mem_table_flush_pending: IntGaugeVec,
+    pub rocskdb_compaction_pending: IntGaugeVec,
+    pub rocskdb_num_running_compactions: IntGaugeVec,
+    pub rocksdb_num_running_flushes: IntGaugeVec,
+    pub rocksdb_estimate_oldest_key_time: IntGaugeVec,
+    pub rocskdb_background_errors: IntGaugeVec,
+}
+
+impl ColumnFamilyMetrics {
+    pub(crate) fn new(registry: &Registry) -> Self {
+        ColumnFamilyMetrics {
+            rocksdb_total_sst_files_size: register_int_gauge_vec_with_registry!(
+                "rocksdb_total_sst_files_size",
+                "The storage size occupied by the column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_size_all_mem_tables: register_int_gauge_vec_with_registry!(
+                "rocksdb_size_all_mem_tables",
+                "The memory size occupied by the column family's in-memory buffer",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_num_snapshots: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_snapshots",
+                "Number of snapshots held for the column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_oldest_snapshot_time: register_int_gauge_vec_with_registry!(
+                "rocksdb_oldest_snapshot_time",
+                "Unit timestamp of the oldest unreleased snapshot",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_actual_delayed_write_rate: register_int_gauge_vec_with_registry!(
+                "rocksdb_actual_delayed_write_rate",
+                "The current actual delayed write rate. 0 means no delay",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_is_write_stopped: register_int_gauge_vec_with_registry!(
+                "rocksdb_is_write_stopped",
+                "A flag indicating whether writes are stopped on this column family. 1 indicates writes have been stopped.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_block_cache_capacity: register_int_gauge_vec_with_registry!(
+                "rocksdb_block_cache_capacity",
+                "The block cache capacity of the column family.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_block_cache_usage: register_int_gauge_vec_with_registry!(
+                "rocksdb_block_cache_usage",
+                "The memory size used by the column family in the block cache.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_block_cache_pinned_usage: register_int_gauge_vec_with_registry!(
+                "rocksdb_block_cache_pinned_usage",
+                "The memory size used by the column family in the block cache where entries are pinned",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocskdb_estimate_table_readers_mem: register_int_gauge_vec_with_registry!(
+                "rocskdb_estimate_table_readers_mem",
+                "The estimated memory size used for reading SST tables in this column
+                family such as filters and index blocks. Note that this number does not
+                include the memory used in block cache.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_mem_table_flush_pending: register_int_gauge_vec_with_registry!(
+                "rocksdb_mem_table_flush_pending",
+                "A 1 or 0 flag indicating whether a memtable flush is pending.
+                If this number is 1, it means a memtable is waiting for being flushed,
+                but there might be too many L0 files that prevents it from being flushed.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocskdb_compaction_pending: register_int_gauge_vec_with_registry!(
+                "rocskdb_compaction_pending",
+                "A 1 or 0 flag indicating whether a compaction job is pending.
+                If this number is 1, it means some part of the column family requires
+                compaction in order to maintain shape of LSM tree, but the compaction
+                is pending because the desired compaction job is either waiting for
+                other dependnent compactions to be finished or waiting for an available
+                compaction thread.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocskdb_num_running_compactions: register_int_gauge_vec_with_registry!(
+                "rocskdb_num_running_compactions",
+                "The number of compactions that are currently running for the column family.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_num_running_flushes: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_running_flushes",
+                "The number of flushes that are currently running for the column family.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_estimate_oldest_key_time: register_int_gauge_vec_with_registry!(
+                "rocksdb_estimate_oldest_key_time",
+                "Estimation of the oldest key timestamp in the DB. Only vailable
+                for FIFO compaction with compaction_options_fifo.allow_compaction = false.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocskdb_background_errors: register_int_gauge_vec_with_registry!(
+                "rocskdb_background_errors",
+                "The accumulated number of RocksDB background errors.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct OperationMetrics {
     pub rocksdb_iter_latency_seconds: HistogramVec,
     pub rocksdb_iter_bytes: HistogramVec,
     pub rocksdb_get_latency_seconds: HistogramVec,
@@ -72,13 +223,9 @@ pub struct DBMetrics {
     pub rocksdb_batch_commit_bytes: HistogramVec,
 }
 
-impl DBMetrics {
-    pub fn make_db_metrics(registry: &Registry) -> &'static Arc<DBMetrics> {
-        static ONCE: OnceCell<Arc<DBMetrics>> = OnceCell::new();
-        ONCE.get_or_init(|| Arc::new(DBMetrics::new(registry)))
-    }
+impl OperationMetrics {
     pub(crate) fn new(registry: &Registry) -> Self {
-        DBMetrics {
+        OperationMetrics {
             rocksdb_iter_latency_seconds: register_histogram_vec_with_registry!(
                 "rocksdb_iter_latency_seconds",
                 "Rocksdb iter latency in seconds",
@@ -170,5 +317,24 @@ impl DBMetrics {
             )
             .unwrap(),
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct DBMetrics {
+    pub op_metrics: OperationMetrics,
+    pub cf_metrics: ColumnFamilyMetrics,
+}
+
+impl DBMetrics {
+    pub(crate) fn new(registry: &Registry) -> Self {
+        DBMetrics {
+            op_metrics: OperationMetrics::new(registry),
+            cf_metrics: ColumnFamilyMetrics::new(registry),
+        }
+    }
+    pub fn make_db_metrics(registry: &Registry) -> &'static Arc<DBMetrics> {
+        static ONCE: OnceCell<Arc<DBMetrics>> = OnceCell::new();
+        ONCE.get_or_init(|| Arc::new(DBMetrics::new(registry)))
     }
 }

--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -75,6 +75,7 @@ pub struct ColumnFamilyMetrics {
     pub rocksdb_num_running_flushes: IntGaugeVec,
     pub rocksdb_estimate_oldest_key_time: IntGaugeVec,
     pub rocskdb_background_errors: IntGaugeVec,
+    pub rocksdb_estimated_num_keys: IntGaugeVec,
 }
 
 impl ColumnFamilyMetrics {
@@ -191,6 +192,13 @@ impl ColumnFamilyMetrics {
                 "rocksdb_estimate_oldest_key_time",
                 "Estimation of the oldest key timestamp in the DB. Only vailable
                 for FIFO compaction with compaction_options_fifo.allow_compaction = false.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_estimated_num_keys: register_int_gauge_vec_with_registry!(
+                "rocksdb_estimated_num_keys",
+                "The estimated number of keys in the table",
                 &["cf_name"],
                 registry,
             )

--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -19,6 +19,8 @@ pub enum TypedStoreError {
     UnregisteredColumn(String),
     #[error("a batch operation can't operate across databases")]
     CrossDBBatch,
+    #[error("Metric reporting thread failed with error")]
+    MetricsReporting,
 }
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, Error)]

--- a/crates/typed-store/src/rocks/iter.rs
+++ b/crates/typed-store/src/rocks/iter.rs
@@ -48,6 +48,7 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for Iter<'a, K, V> {
             let report_metrics = if self.read_sample_interval.sample() {
                 let timer = self
                     .db_metrics
+                    .op_metrics
                     .rocksdb_iter_latency_seconds
                     .with_label_values(&[&self.cf])
                     .start_timer();
@@ -70,6 +71,7 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for Iter<'a, K, V> {
             let value = bincode::deserialize(raw_value).ok();
             if report_metrics.is_some() {
                 self.db_metrics
+                    .op_metrics
                     .rocksdb_iter_bytes
                     .with_label_values(&[&self.cf])
                     .observe((raw_key.len() + raw_value.len()) as f64);

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -22,10 +22,14 @@ async fn test_reopen() {
             .expect("Failed to open storage");
         db.insert(&123456789, &"123456789".to_string())
             .expect("Failed to insert");
-        db.rocksdb
+        db
     };
-    let db = DBMap::<u32, String>::reopen(&arc, None, &Arc::new(DBMetrics::new(&Registry::new())))
-        .expect("Failed to re-open storage");
+    let db = DBMap::<u32, String>::reopen(
+        &arc.rocksdb,
+        None,
+        &Arc::new(DBMetrics::new(&Registry::new())),
+    )
+    .expect("Failed to re-open storage");
     assert!(db
         .contains_key(&123456789)
         .expect("Failed to retrieve item in storage"));


### PR DESCRIPTION
This PR allows us to capture rocksdb internal metrics per column family. These metrics are updated in the background