### PR TITLE
chore: update nexlint

### DIFF
--- a/crates/x/Cargo.toml
+++ b/crates/x/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.58"
 clap = { version = "4.0.8", features = ["derive"] }
-nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "5bf35a12bfaed45328288933e222006ee4e99c28" }
-nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "5bf35a12bfaed45328288933e222006ee4e99c28" }
+nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "5926141c20414814290bb1b04bd3b2238bbbc90e" }
+nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "5926141c20414814290bb1b04bd3b2238bbbc90e" }


### PR DESCRIPTION
This updates nexlint in order to pick up a dependency update in guppy, in order to fix errors that are cropping up in ci:

```
Error: while building package graph

Caused by:
    failed to construct package graph: for package 'windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)': for dependency 'windows_aarch64_gnullvm', parsing target 'aarch64-pc-windows-gnullvm' failed: unknown target triple
```