### PR TITLE
Make sync use full feature

### DIFF
--- a/crates/typed-store-derive/Cargo.toml
+++ b/crates/typed-store-derive/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.47"
 quote = "1.0.9"
-syn = { version = "1.0.102", features = ["derive"] }
+syn = { version = "1.0.102", features = ["full"] }
 tokio = { version = "1.21.2", features = ["full"] }
 
 [dev-dependencies]


### PR DESCRIPTION
cargo fails to publish this crate today because sync only uses "derive" feature, instead we should use "full". The failure is here:
https://github.com/MystenLabs/mysten-infra/actions/runs/3291600851/jobs/5494042110#step:8:79